### PR TITLE
Reuse session, drop SimpleCookie workaround, fix logging hygiene

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyomnisense"          
-version = "0.1.2"             
+version = "0.1.3"             
 description = "Python library for accessing Omnisense sensor data from omnisense.com"
 readme = "README.md"          
 license = { text = "MIT" }    

--- a/src/pyomnisense/__init__.py
+++ b/src/pyomnisense/__init__.py
@@ -1,4 +1,4 @@
 from .omnisense import Omnisense
 
 __all__ = ["Omnisense"]
-__version__ = "0.1.1"
+__version__ = "0.1.3"

--- a/src/pyomnisense/omnisense.py
+++ b/src/pyomnisense/omnisense.py
@@ -1,295 +1,329 @@
 import logging
+import re
+from typing import Dict, List, Optional, Union
+
 import aiohttp
 from bs4 import BeautifulSoup
-import re
-from typing import List, Dict, Optional, Union
-from urllib.parse import urlencode
-from http.cookies import SimpleCookie
 
 _LOGGER = logging.getLogger(__name__)
-logging.basicConfig(level=logging.DEBUG)
-
-CONF_SITE_NAME = "site_name"       # The name of the site (e.g., "home")
-CONF_SENSOR_IDS = "sensor_ids"     # List of sensor IDs to extract (empty = all)
-CONF_USERNAME = "username"         # Login username
-CONF_PASSWORD = "password"         # Login password
 
 HOST_URL = "https://www.omnisense.com"
 LOGIN_URL = "https://www.omnisense.com/user_login.asp"
 SITE_LIST_URL = "https://www.omnisense.com/site_select.asp"
 SENSOR_LIST_URL = "https://www.omnisense.com/sensor_select.asp"
 
+_DEFAULT_TIMEOUT_SECS = 30
+
+# Path fragment used to detect "the server bounced us back to the login page",
+# i.e. the cached session expired and we need to log in again.
+_LOGIN_PATH = "/user_login.asp"
+
+
 class Omnisense:
 
-    def __init__(self): 
-        self._username = None
-        self._password = None
-        self._session = None
-        
+    def __init__(self):
+        self._username: Optional[str] = None
+        self._password: Optional[str] = None
+        self._session: Optional[aiohttp.ClientSession] = None
+
         self.headers = {
-            "User-Agent": "Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) "
-                        "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 "
-                        "Mobile Safari/537.36 Edg/138.0.0.0",
+            "User-Agent": (
+                "Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) "
+                "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 "
+                "Mobile Safari/537.36 Edg/138.0.0.0"
+            ),
         }
-        
-        #self.proxy_url = "http://127.0.0.1:8888"
-        self.proxy_url = None  # Set to None to disable proxy, or provide a valid proxy URL if needed
-                        
-        
-    
-    async def login(self, username: str=None, password: str=None) -> bool:
-        if not username or not password:
-            if not self._username or not self._password:
-                _LOGGER.error("No username or password provided.")
-                raise Exception("No username or password provided.")
-        else:
+
+        # Set to a URL (e.g. "http://127.0.0.1:8888") to route traffic through
+        # a debugging proxy; leave as None for normal operation.
+        self.proxy_url: Optional[str] = None
+
+    def _open_session(self) -> None:
+        # quote_cookie=False is load-bearing: omnisense.com is a classic ASP
+        # site whose Set-Cookie values contain characters ('=', '+') that
+        # aiohttp's default cookie jar would re-quote, breaking subsequent
+        # authenticated requests. With quote_cookie=False the jar preserves
+        # the server's cookie values verbatim, so we can let aiohttp manage
+        # session cookies normally instead of building Cookie headers by hand.
+        jar = aiohttp.CookieJar(quote_cookie=False)
+        self._session = aiohttp.ClientSession(
+            cookie_jar=jar,
+            headers=self.headers,
+            timeout=aiohttp.ClientTimeout(total=_DEFAULT_TIMEOUT_SECS),
+        )
+
+    async def close(self) -> None:
+        if self._session is not None:
+            await self._session.close()
+            self._session = None
+
+    async def login(
+        self,
+        username: Optional[str] = None,
+        password: Optional[str] = None,
+    ) -> bool:
+        """Log in to omnisense.com.
+
+        Pass both ``username`` and ``password`` to set / replace cached
+        credentials, or neither to reuse the credentials supplied on a
+        previous successful call (this is what allows transparent
+        re-login when the server expires our session).
+
+        Returns ``True`` on success, ``False`` if the server rejected the
+        credentials. Raises if no credentials are available, or if only
+        one of username/password is supplied.
+        """
+        if (username is None) != (password is None):
+            raise Exception("Provide both username and password, or neither.")
+        if username is not None:
             self._username = username
             self._password = password
-            
-       
+        if not self._username or not self._password:
+            _LOGGER.error("No username or password provided.")
+            raise Exception("No username or password provided.")
+
+        # Always close any prior session before allocating a new one,
+        # otherwise repeated login() calls leak ClientSessions / sockets.
+        await self.close()
+        self._open_session()
+
         payload = {
             "userId": self._username,
             "userPass": self._password,
             "target": "",
             "btnAct": "Log-In",
         }
-        
-        self._session = aiohttp.ClientSession()
-        
-        # 1. POST login (no redirects)
-        async with self._session.post(LOGIN_URL, data=payload, proxy=self.proxy_url, headers=self.headers, allow_redirects=False) as resp:
-            _LOGGER.debug("POST %s status: %s", LOGIN_URL, resp.status)
-            _LOGGER.debug("POST response headers: %s", dict(resp.headers))
-            _LOGGER.debug("POST response cookies: %s", resp.cookies)
-            # 2. Build manual Cookie header (no quotes)
-            set_cookie_headers = resp.headers.getall('Set-Cookie', [])
-            _LOGGER.debug("Set-Cookie headers: %s", set_cookie_headers)
-            cookies = SimpleCookie()
-            for h in set_cookie_headers:
-                _LOGGER.debug(f"Processing Set-Cookie header: {h}")
-                if h.startswith("userPNSToken=login+failed;"):
-                    _LOGGER.error("Login failed: userPNSToken=login+failed detected in cookies.")
-                    await self._session.close()
-                    self._session = None
-                    return False
-                cookies.load(h)
-            _LOGGER.debug("Parsed cookies: %s", {k: v.value for k, v in cookies.items()})
 
-            # --- IMPORTANT WORKAROUND ---
-            # aiohttp (and the Python standard library) will quote cookie values containing special characters,
-            # which breaks compatibility with legacy classic ASP and some ASP.NET applications.
-            # These servers expect unquoted cookie values—even if the value contains '=' or other special chars.
-            # The fix: manually build the Cookie header and add this to the headers rather than relying on aiohttp's cookie handling.
-            cookie_header = "; ".join(f"{key}={m.value}" for key, m in cookies.items())
-            _LOGGER.debug("Manual Cookie header: %s", cookie_header)
-            # --- END WORKAROUND ---
+        # POST the login form but don't follow the redirect yet, so we can
+        # inspect the failure-sentinel cookie before making more requests.
+        async with self._session.post(
+            LOGIN_URL,
+            data=payload,
+            proxy=self.proxy_url,
+            allow_redirects=False,
+        ) as resp:
+            _LOGGER.debug("Login POST status: %s", resp.status)
 
-            # 3. Get the redirect location
-            location = resp.headers.get('Location')
-            _LOGGER.debug("Redirect location: %s", location)
+            token = resp.cookies.get("userPNSToken")
+            if token is not None and "failed" in token.value.lower():
+                _LOGGER.warning("Login rejected by server.")
+                await self.close()
+                return False
+
+            location = resp.headers.get("Location")
             if not location:
-                _LOGGER.error("No redirect location after login.")
+                _LOGGER.error(
+                    "Login POST returned status %s with no redirect location.",
+                    resp.status,
+                )
+                await self.close()
                 return False
             if not location.startswith("http"):
                 location = HOST_URL + location
-                _LOGGER.debug("Full redirect location: %s", location)
 
-            # 4. Clear session cookies so aiohttp doesn't interfere
-            self._session.cookie_jar.clear()
-            _LOGGER.debug("Session cookies cleared.")
+        # Follow the redirect. Cookies set on the POST response are now in
+        # the jar and will be attached automatically.
+        async with self._session.get(location, proxy=self.proxy_url) as resp:
+            if resp.status != 200:
+                _LOGGER.error(
+                    "Post-login GET %s returned status %s", location, resp.status
+                )
+                await self.close()
+                return False
+            if _LOGIN_PATH in str(resp.url):
+                _LOGGER.warning("Post-login GET landed back on the login page.")
+                await self.close()
+                return False
 
-            # 5. Make GET to redirect target with manual Cookie header
-            self.headers['Cookie'] = cookie_header
-            _LOGGER.debug("GET %s with headers: %s", location, self.headers)
-            async with self._session.get(location, proxy=self.proxy_url, headers=self.headers) as resp2:
-                final_url = str(resp2.url)
-                _LOGGER.debug("GET response status: %s", resp2.status)
-                _LOGGER.debug("GET response URL: %s", final_url)
-                # Optionally, check resp2.status and/or content for further validation
+        return True
 
-            # 6. Return True if we landed on the intended URL
-            _LOGGER.debug("Final URL after login: %s (success=%s)", final_url, final_url == location)
-            return final_url == location
-                
-
-    async def close(self):
-        if self._session:
-            await self._session.close()
-            self._session = None        
-        
-    async def get_site_list(self) -> dict:
-        ''' fetch the available sites
-        
-        Returns: dict: Returns a dictionary of {site_id: site_name}
-
-        '''
-        
-        if self._session is None:
+    async def _ensure_session(self) -> None:
+        if self._session is None or self._session.closed:
             if not await self.login():
-                return {}
+                raise Exception("Login failed.")
 
+    async def _fetch_html(self, url: str) -> str:
+        """GET ``url``, transparently re-logging in once if the session expired.
+
+        Detects expiry by checking whether the (post-redirect) response URL
+        landed on the login page.
+        """
+        await self._ensure_session()
+
+        for attempt in (0, 1):
+            async with self._session.get(url, proxy=self.proxy_url) as resp:
+                if resp.status != 200:
+                    raise Exception(f"GET {url} returned status {resp.status}")
+                final_url = str(resp.url)
+                if _LOGIN_PATH in final_url:
+                    if attempt == 0:
+                        _LOGGER.info("Session expired; re-logging in.")
+                        if not await self.login():
+                            raise Exception("Re-login failed.")
+                        continue
+                    raise Exception(
+                        "Server kept redirecting to the login page after re-login."
+                    )
+                return await resp.text()
+
+        raise Exception("unreachable")
+
+    async def get_site_list(self) -> dict:
+        """Fetch the available sites.
+
+        Returns:
+            dict: ``{site_id: site_name}``. Returns an empty dict on error.
+        """
         try:
-            async with self._session.get(SITE_LIST_URL, proxy=self.proxy_url, headers=self.headers, timeout=10) as response:
-                if response.status != 200:
-                    raise Exception("Error fetching job sites page.")
-                soup = BeautifulSoup(await response.text(), "html.parser")
+            text = await self._fetch_html(SITE_LIST_URL)
         except Exception as err:
             _LOGGER.error("Error fetching site list: %s", err)
             return {}
 
+        soup = BeautifulSoup(text, "html.parser")
         sites = {}
         for link in soup.find_all("a", onclick=True):
-            onclick = link.get("onclick", "")
-            match = re.search(r"ShowSiteDetail\('(\d+)'\)", onclick)
+            match = re.search(r"ShowSiteDetail\('(\d+)'\)", link.get("onclick", ""))
             if match:
-                site_id = match.group(1)
-                site_name = link.get_text(strip=True)
-                sites[site_id] = site_name
-
+                sites[match.group(1)] = link.get_text(strip=True)
         return sites
-    
-    async def get_site_sensor_list(self, site_ids: Union[str, List[str], Dict[str, str]] = None) -> Dict[str, Dict[str, str]]:
-        '''  Fetch sensors for the selected site using the stored credentials.  
-        
+
+    async def get_site_sensor_list(
+        self,
+        site_ids: Union[str, List[str], Dict[str, str]] = None,
+    ) -> Dict[str, Dict[str, str]]:
+        """Fetch sensors for the selected site(s) and project to the
+        ``{description, sensor_type, site_name}`` subset.
+
         Args:
-            site_ids (Union[str, List[str], Dict[str, str]]) : can be a dictionary in the form {site_id : site_name} or a list of site_id strings or a single site_id string. 
-                If not provided all sensors from all sites will be returned.
-                
-        Returns: Dict[str, Dict[str, str, str]]: Returns a dictionary of Dict[sensor_id, Dict[description, sensor_type, site_name ]]'''
-
-        if self._session is None:
-            if not await self.login():
-                return {}
-            
-        if not site_ids:
-            site_ids = await self.get_site_list()
-            
-        if isinstance(site_ids, str):
-            site_ids = [site_ids]
-        elif isinstance(site_ids, list):
-            #do nothing
-            pass
-        elif isinstance(site_ids, dict):
-            site_ids = list(site_ids.keys())  # Extract only the keys as a list
-        else:
-            raise TypeError("Unsupported data type, expected str, list of str, or dict with str keys.")
-                     
-        sensors = {}
-
+            site_ids: ``{site_id: site_name}`` dict, list of site_id strings,
+                or a single site_id string. If omitted, all sites are
+                queried.
+        """
         try:
             sensor_data = await self.get_sensor_data(site_ids)
-
-            #if there is no sensor data, return an empty dictionary
             if not sensor_data:
                 return {}
-
-            #only return a dictionary of sensor_id: description, sensor_type, site_name
-            for sensor_id, sensor_info in sensor_data.items():
-                sensors[sensor_id] = {
-                    "description" : sensor_info["description"], 
-                    "sensor_type" : sensor_info["sensor_type"], 
-                    "site_name" : sensor_info["site_name"]
+            return {
+                sid: {
+                    "description": info["description"],
+                    "sensor_type": info["sensor_type"],
+                    "site_name": info["site_name"],
                 }
-
+                for sid, info in sensor_data.items()
+            }
         except Exception as e:
             _LOGGER.error("Error fetching sensors: %s", e)
             return {}
-        
-        return sensors
 
-    async def get_sensor_data(self, site_ids: Union[str, List[str], Dict[str, str]] = None, sensor_ids: Union[str, List[str]] = []) -> dict:
-        ''' Fetch the sensor data
-        
-        Args: 
-            site_ids (Union[str, List[str], Dict[str, str]]): A single site_id string or a list of site_id strings. If not provided, all sites will be searched.
-            sensor_ids (Union[str, List[str]]): A single sensor_id string or a list of sensor_id strings. If not provided, all sensors will be returned from all site(s).
-            
-        Returns: dict: Returns a dictionary of sensor data in the form of sensor_id: { description, last_activity, status, temperature, relative_humidity, absolute_humidity, dew_point, wood_pct, battery_voltage, sensor_type, site_name }
-        '''
-        
-        if self._session is None:
-            if not await self.login():
-                return {}
-            
+    async def get_sensor_data(
+        self,
+        site_ids: Union[str, List[str], Dict[str, str]] = None,
+        sensor_ids: Union[str, List[str]] = None,
+    ) -> dict:
+        """Fetch sensor readings for one or more sites.
+
+        Args:
+            site_ids: A single site_id string, list of site_id strings,
+                or ``{site_id: site_name}`` dict. If omitted, all sites are
+                queried.
+            sensor_ids: Optional filter; a single sensor_id or a list. If
+                omitted, all sensors are returned.
+
+        Returns:
+            dict keyed by sensor_id, where each value contains
+            ``description``, ``last_activity``, ``status``, ``temperature``,
+            ``relative_humidity``, ``absolute_humidity``, ``dew_point``,
+            ``wood_pct``, ``battery_voltage``, ``sensor_type``,
+            ``sensor_id`` and ``site_name``.
+        """
         if not site_ids:
             site_ids = await self.get_site_list()
-            
+
         if isinstance(site_ids, str):
             site_ids = [site_ids]
         elif isinstance(site_ids, list):
-            #do nothing
             pass
         elif isinstance(site_ids, dict):
-            site_ids = list(site_ids.keys())  # Extract only the keys as a list
+            site_ids = list(site_ids.keys())
         else:
-            raise TypeError("Unsupported data type, expected str, list of str, or dict with str keys.")
+            raise TypeError(
+                "Unsupported data type, expected str, list of str, or dict with str keys."
+            )
 
-        if isinstance(sensor_ids, str):
+        if sensor_ids is None:
+            sensor_ids = []
+        elif isinstance(sensor_ids, str):
             sensor_ids = [sensor_ids]
 
-        all_sensors = {}
+        all_sensors: Dict[str, dict] = {}
         for site_id in site_ids:
             sensor_page_url = f"{SENSOR_LIST_URL}?siteNbr={site_id}"
 
             try:
-                async with self._session.get(sensor_page_url, proxy=self.proxy_url, headers=self.headers, timeout=10) as response:
-                    if response.status != 200:
-                        raise Exception(f"Error fetching sensor data for site id '{site_id}'.")
-                    soup = BeautifulSoup(await response.text(), "html.parser")
+                text = await self._fetch_html(sensor_page_url)
+            except Exception:
+                _LOGGER.exception(
+                    "Error fetching sensor data for site id '%s'.", site_id
+                )
+                continue
 
-                    # Extract site name from the title
-                    title_text = soup.find("title").get_text().strip()
-                    # Use a regular expression to remove "Sensors for "
-                    match = re.search(r"Sensors for\s+(.+)", title_text)
+            try:
+                soup = BeautifulSoup(text, "html.parser")
+
+                site_name = None
+                title = soup.find("title")
+                if title and title.get_text():
+                    match = re.search(r"Sensors for\s+(.+)", title.get_text().strip())
                     if match:
                         site_name = match.group(1)
 
-                    #extract individual sensor data
-                    for table in soup.select("table.sortable.table"):
-                        sensor_type = None
-                        table_id = table.get("id", "")
-                        if table_id.startswith("sensorType"):
-                            sensor_type = f"S-{table_id[len('sensorType'):]}"
-                        if not sensor_type:
-                            caption = table.find("caption")
-                            if caption and caption.text:
-                                m = re.search(r"Sensor Type\s*(\d+)", caption.text)
-                                if m:
-                                    sensor_type = f"S-{m.group(1)}"
-                        for row in table.select("tr.sensorTable"):
-                            tds = row.find_all("td")
-                            if len(tds) >= 10:
-                                sid = tds[0].get_text(strip=True)
-                                if sensor_ids and sid not in sensor_ids:
-                                    continue
-                                try:
-                                    temperature = float(tds[4].get_text(strip=True))
-                                except ValueError:
-                                    temperature = None
+                for table in soup.select("table.sortable.table"):
+                    sensor_type = None
+                    table_id = table.get("id", "")
+                    if table_id.startswith("sensorType"):
+                        sensor_type = f"S-{table_id[len('sensorType'):]}"
+                    if not sensor_type:
+                        caption = table.find("caption")
+                        if caption and caption.text:
+                            m = re.search(r"Sensor Type\s*(\d+)", caption.text)
+                            if m:
+                                sensor_type = f"S-{m.group(1)}"
 
-                                desc = tds[1].get_text(strip=True)
-                                if desc == "~click to edit~":
-                                    desc = "<description not set>"
+                    for row in table.select("tr.sensorTable"):
+                        tds = row.find_all("td")
+                        if len(tds) < 10:
+                            continue
+                        sid = tds[0].get_text(strip=True)
+                        if sensor_ids and sid not in sensor_ids:
+                            continue
+                        try:
+                            temperature = float(tds[4].get_text(strip=True))
+                        except ValueError:
+                            temperature = None
 
-                                all_sensors[sid] = {
-                                    "description": desc,
-                                    "last_activity": tds[2].get_text(strip=True),
-                                    "status": tds[3].get_text(strip=True),
-                                    "temperature": temperature,
-                                    "relative_humidity": tds[5].get_text(strip=True),
-                                    "absolute_humidity": tds[6].get_text(strip=True),
-                                    "dew_point": tds[7].get_text(strip=True),
-                                    "wood_pct": tds[8].get_text(strip=True),
-                                    "battery_voltage": tds[9].get_text(strip=True),
-                                    "sensor_type": sensor_type,
-                                    "sensor_id": sid,
-                                    "site_name": site_name,
-                                }
+                        desc = tds[1].get_text(strip=True)
+                        if desc == "~click to edit~":
+                            desc = "<description not set>"
 
+                        all_sensors[sid] = {
+                            "description": desc,
+                            "last_activity": tds[2].get_text(strip=True),
+                            "status": tds[3].get_text(strip=True),
+                            "temperature": temperature,
+                            "relative_humidity": tds[5].get_text(strip=True),
+                            "absolute_humidity": tds[6].get_text(strip=True),
+                            "dew_point": tds[7].get_text(strip=True),
+                            "wood_pct": tds[8].get_text(strip=True),
+                            "battery_voltage": tds[9].get_text(strip=True),
+                            "sensor_type": sensor_type,
+                            "sensor_id": sid,
+                            "site_name": site_name,
+                        }
             except Exception:
-                _LOGGER.error(f"Error fetching/parsing sensor data for site id '{site_id}'.")
+                _LOGGER.exception(
+                    "Error parsing sensor data for site id '%s'.", site_id
+                )
                 continue
 
         return all_sensors
-
-

--- a/tests/session_reuse_test.py
+++ b/tests/session_reuse_test.py
@@ -1,0 +1,153 @@
+"""Regression tests for session reuse and transparent re-login on expiry.
+
+These cover the behaviour change introduced when we replaced the manual
+SimpleCookie / Cookie-header workaround with a real aiohttp CookieJar
+configured with ``quote_cookie=False``:
+
+* A single ``login()`` should suffice for many subsequent data calls.
+* If the server bounces a data request back to the login page (because
+  the cached session expired), the client should transparently re-login
+  once and retry without the caller having to know.
+"""
+
+import os
+import pytest
+from aioresponses import aioresponses
+
+from pyomnisense.omnisense import (
+    Omnisense,
+    LOGIN_URL,
+    SITE_LIST_URL,
+    SENSOR_LIST_URL,
+    HOST_URL,
+)
+
+
+SAMPLES_DIR = os.path.join(os.path.dirname(__file__), "samples")
+
+
+def _load_sample(name: str) -> str:
+    with open(os.path.join(SAMPLES_DIR, name), "r", encoding="utf-8") as f:
+        return f.read()
+
+
+def _mock_successful_login(m: aioresponses, set_cookie: str = "ASP.NET_SessionId=abc123; Path=/; HttpOnly") -> None:
+    """Register a POST /user_login.asp + GET /site_select.asp pair that
+    together represent one successful login round-trip."""
+    m.post(
+        LOGIN_URL,
+        status=302,
+        headers={"Set-Cookie": set_cookie, "Location": "/site_select.asp"},
+        body="",
+    )
+    m.get(
+        f"{HOST_URL}/site_select.asp",
+        status=200,
+        body="Welcome to your dashboard",
+    )
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_session_is_reused_across_calls():
+    """Two data calls after one login must not trigger a second login.
+
+    If the implementation accidentally re-logs in, the second POST to
+    LOGIN_URL would have no registered response and aioresponses would
+    raise, failing the test.
+    """
+    site_html = _load_sample("site_list.html")
+    sensors_html = _load_sample("sensor_123456.html")
+
+    with aioresponses() as m:
+        _mock_successful_login(m)
+        # One registration each: if the client tries to fetch them twice
+        # (or, worse, re-login between them), aioresponses will fail.
+        m.get(SITE_LIST_URL, status=200, body=site_html)
+        m.get(f"{SENSOR_LIST_URL}?siteNbr=123456", status=200, body=sensors_html)
+
+        omnisense = Omnisense()
+        assert await omnisense.login("user", "pass") is True
+
+        sites = await omnisense.get_site_list()
+        assert sites == {"123456": "MySite", "654321": "FirstSite"}
+
+        sensors = await omnisense.get_sensor_data("123456")
+        assert "2A000001" in sensors
+        assert sensors["2A000001"]["site_name"] == "MySite"
+
+        await omnisense.close()
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_relogin_on_session_expiry():
+    """If a data fetch lands on the login page, the client must re-login
+    once and retry transparently."""
+    site_html = _load_sample("site_list.html")
+
+    with aioresponses() as m:
+        _mock_successful_login(m)
+
+        # First GET of the site list "expires": server redirects to the
+        # login page and aiohttp follows the redirect (default behaviour).
+        m.get(
+            SITE_LIST_URL,
+            status=302,
+            headers={"Location": "/user_login.asp"},
+        )
+        m.get(
+            f"{HOST_URL}/user_login.asp",
+            status=200,
+            body="<html><form>login form here</form></html>",
+        )
+
+        # Transparent re-login: another POST + dashboard GET pair.
+        _mock_successful_login(m, set_cookie="ASP.NET_SessionId=def456; Path=/; HttpOnly")
+
+        # Retry of the original data call now succeeds.
+        m.get(SITE_LIST_URL, status=200, body=site_html)
+
+        omnisense = Omnisense()
+        assert await omnisense.login("user", "pass") is True
+
+        sites = await omnisense.get_site_list()
+        assert sites == {"123456": "MySite", "654321": "FirstSite"}
+
+        await omnisense.close()
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_login_replaces_credentials_atomically():
+    """Passing only one of username/password must be a hard error, not
+    a silent partial update that re-uses cached credentials of the
+    *other* user."""
+    omnisense = Omnisense()
+    with pytest.raises(Exception):
+        await omnisense.login("alice", None)
+    with pytest.raises(Exception):
+        await omnisense.login(None, "secret")
+    await omnisense.close()
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_relogin_closes_old_session():
+    """Calling login() twice must not leak the first ClientSession."""
+    with aioresponses() as m:
+        _mock_successful_login(m)
+        _mock_successful_login(m, set_cookie="ASP.NET_SessionId=def456; Path=/; HttpOnly")
+
+        omnisense = Omnisense()
+        assert await omnisense.login("user", "pass") is True
+        first_session = omnisense._session
+        assert first_session is not None and not first_session.closed
+
+        assert await omnisense.login("user", "pass") is True
+        second_session = omnisense._session
+        assert second_session is not None and not second_session.closed
+        assert second_session is not first_session
+        assert first_session.closed, "previous session was leaked across re-login"
+
+        await omnisense.close()


### PR DESCRIPTION
Addresses the top three items from the code review in #4.

### 1. Logging hygiene (#1 + #2 from the review)
- Drop the module-level `logging.basicConfig(level=logging.DEBUG)` so importing this library no longer reconfigures the host application's root logger.
- Stop emitting cookies / `Set-Cookie` headers / merged `Cookie` headers at DEBUG. The session token used to leak into every consumer's logs by default.

### 2. Replace the SimpleCookie workaround with `CookieJar(quote_cookie=False)` (#7 from the review)
- aiohttp 3.10+ supports preserving unquoted cookie values via the `quote_cookie=False` cookie-jar option, and we already pin `aiohttp>=3.11.12`. Using it lets aiohttp manage cookies across requests instead of manually parsing `Set-Cookie` and splicing a `Cookie` header onto `self.headers`.
- As a side effect, the session timeout is now configured once on the `ClientSession` instead of per-request, and `self.headers` is no longer mutated to stash auth state.

### 3. Stop leaking sessions on re-login and detect session expiry (#4 + #6 from the review)
- `login()` now closes any prior `ClientSession` before allocating a new one, so repeated calls no longer leak sockets.
- New `_fetch_html` helper detects responses that landed on `/user_login.asp` (server bounced us due to an expired session) and transparently re-logs in once before retrying, instead of silently returning empty data.
- `login()` no longer silently reuses cached credentials when only one of username/password is supplied; partial credentials now raise.

### Also
- Remove the dead Home Assistant `CONF_*` constants and unused `urlencode` / `SimpleCookie` imports.
- Bump version to `0.1.3`.
- Add regression tests covering: session reuse across calls, transparent re-login on expiry, partial-credentials rejection, and no-leak on repeated `login()`.

### Verification
`pytest -m offline` now reports **24 passed** (20 existing + 4 new regression tests).

Refs #4.