### PR TITLE
API polish: typed exceptions, async context manager, TypedDict, py>=3.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,14 @@ pyomnisense is a Python library for accessing Omnisense sensor data directly fro
 - Retrieve a list of sites with sensor data
 - Fetch detailed sensor data for a selected site
 - Asynchronous methods using aiohttp
+- Transparent re-login if the server expires the session between calls
 
 ## Install this repo
 
 Clone the repository and install in editable mode:
 
 ```bash
-git clone https://github.com/your_username/pyomnisense.git
+git clone https://github.com/sslivins/pyomnisense.git
 cd pyomnisense
 pip install -e .
 ```
@@ -28,31 +29,32 @@ pip install pyomnisense
 ## Usage
 
 ```python
-from pyomnisense import Omnisense
+import asyncio
+from pyomnisense import Omnisense, OmnisenseAuthError
 
 async def main():
-    omnisense = Omnisense()
-    # Login with your credentials
-    await omnisense.login("your_username", "your_password")
-    
-    # Get list of sites
-    sites = await omnisense.get_site_list()
-    print("Available sites:", sites)
+    async with Omnisense() as omnisense:
+        try:
+            await omnisense.login("your_username", "your_password")
+        except OmnisenseAuthError as err:
+            print(f"Login failed: {err}")
+            return
 
-    sensor_data = await omnisense.get_sensor_data(sites)
+        sites = await omnisense.get_site_list()
+        print("Available sites:", sites)
 
-    print("Sensor Data for Site:", sensor_data)
-    
-    # When done, close the session
-    await omnisense.close()
+        sensor_data = await omnisense.get_sensor_data(sites)
+        print("Sensor data:", sensor_data)
 
-import asyncio
 asyncio.run(main())
 ```
 
-Replace `"your_username"` and `"your_password"` with your actual Omnisense credentials. For more details, refer to the documentation or explore the source code.
+Replace `"your_username"` and `"your_password"` with your actual Omnisense credentials. The `async with` block guarantees the underlying HTTP session is closed even on errors.
 
 ## Testing
 Tests are written using pytest and pytest-asyncio. You can run tests as follows:
 
-pytest
+```bash
+pytest -m offline
+```
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,16 +6,19 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyomnisense"          
-version = "0.1.3"             
+version = "0.2.0"             
 description = "Python library for accessing Omnisense sensor data from omnisense.com"
 readme = "README.md"          
 license = { text = "MIT" }    
 authors = [
   { name = "Stefan Slivinski", email = "sslivins@gmail.com" }
 ]
-requires-python = ">=3.7"
+requires-python = ">=3.10"
 classifiers = [
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent"
 ]

--- a/src/pyomnisense/__init__.py
+++ b/src/pyomnisense/__init__.py
@@ -1,4 +1,14 @@
-from .omnisense import Omnisense
+from .omnisense import (
+    Omnisense,
+    OmnisenseAuthError,
+    OmnisenseError,
+    SensorReading,
+)
 
-__all__ = ["Omnisense"]
-__version__ = "0.1.3"
+__all__ = [
+    "Omnisense",
+    "OmnisenseAuthError",
+    "OmnisenseError",
+    "SensorReading",
+]
+__version__ = "0.2.0"

--- a/src/pyomnisense/omnisense.py
+++ b/src/pyomnisense/omnisense.py
@@ -1,6 +1,6 @@
 import logging
 import re
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional, TypedDict, Union
 
 import aiohttp
 from bs4 import BeautifulSoup
@@ -17,6 +17,32 @@ _DEFAULT_TIMEOUT_SECS = 30
 # Path fragment used to detect "the server bounced us back to the login page",
 # i.e. the cached session expired and we need to log in again.
 _LOGIN_PATH = "/user_login.asp"
+
+
+class OmnisenseError(Exception):
+    """Base class for all errors raised by this library."""
+
+
+class OmnisenseAuthError(OmnisenseError):
+    """Raised for authentication / session problems (missing credentials,
+    rejected credentials, expired session that could not be re-established)."""
+
+
+class SensorReading(TypedDict):
+    """Shape of a single sensor's reading as returned by ``get_sensor_data``."""
+
+    description: str
+    last_activity: str
+    status: str
+    temperature: Optional[float]
+    relative_humidity: str
+    absolute_humidity: str
+    dew_point: str
+    wood_pct: str
+    battery_voltage: str
+    sensor_type: Optional[str]
+    sensor_id: str
+    site_name: Optional[str]
 
 
 class Omnisense:
@@ -57,6 +83,12 @@ class Omnisense:
             await self._session.close()
             self._session = None
 
+    async def __aenter__(self) -> "Omnisense":
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        await self.close()
+
     async def login(
         self,
         username: Optional[str] = None,
@@ -70,17 +102,17 @@ class Omnisense:
         re-login when the server expires our session).
 
         Returns ``True`` on success, ``False`` if the server rejected the
-        credentials. Raises if no credentials are available, or if only
-        one of username/password is supplied.
+        credentials. Raises ``OmnisenseAuthError`` if no credentials are
+        available, or if only one of username/password is supplied.
         """
         if (username is None) != (password is None):
-            raise Exception("Provide both username and password, or neither.")
+            raise OmnisenseAuthError("Provide both username and password, or neither.")
         if username is not None:
             self._username = username
             self._password = password
         if not self._username or not self._password:
             _LOGGER.error("No username or password provided.")
-            raise Exception("No username or password provided.")
+            raise OmnisenseAuthError("No username or password provided.")
 
         # Always close any prior session before allocating a new one,
         # otherwise repeated login() calls leak ClientSessions / sockets.
@@ -140,7 +172,7 @@ class Omnisense:
     async def _ensure_session(self) -> None:
         if self._session is None or self._session.closed:
             if not await self.login():
-                raise Exception("Login failed.")
+                raise OmnisenseAuthError("Login failed.")
 
     async def _fetch_html(self, url: str) -> str:
         """GET ``url``, transparently re-logging in once if the session expired.
@@ -153,20 +185,22 @@ class Omnisense:
         for attempt in (0, 1):
             async with self._session.get(url, proxy=self.proxy_url) as resp:
                 if resp.status != 200:
-                    raise Exception(f"GET {url} returned status {resp.status}")
+                    raise OmnisenseError(
+                        f"GET {url} returned status {resp.status}"
+                    )
                 final_url = str(resp.url)
                 if _LOGIN_PATH in final_url:
                     if attempt == 0:
                         _LOGGER.info("Session expired; re-logging in.")
                         if not await self.login():
-                            raise Exception("Re-login failed.")
+                            raise OmnisenseAuthError("Re-login failed.")
                         continue
-                    raise Exception(
+                    raise OmnisenseAuthError(
                         "Server kept redirecting to the login page after re-login."
                     )
                 return await resp.text()
 
-        raise Exception("unreachable")
+        raise OmnisenseError("unreachable")
 
     async def get_site_list(self) -> dict:
         """Fetch the available sites.
@@ -191,7 +225,7 @@ class Omnisense:
     async def get_site_sensor_list(
         self,
         site_ids: Union[str, List[str], Dict[str, str]] = None,
-    ) -> Dict[str, Dict[str, str]]:
+    ) -> Dict[str, Dict[str, Optional[str]]]:
         """Fetch sensors for the selected site(s) and project to the
         ``{description, sensor_type, site_name}`` subset.
 
@@ -220,7 +254,7 @@ class Omnisense:
         self,
         site_ids: Union[str, List[str], Dict[str, str]] = None,
         sensor_ids: Union[str, List[str]] = None,
-    ) -> dict:
+    ) -> Dict[str, SensorReading]:
         """Fetch sensor readings for one or more sites.
 
         Args:
@@ -256,7 +290,7 @@ class Omnisense:
         elif isinstance(sensor_ids, str):
             sensor_ids = [sensor_ids]
 
-        all_sensors: Dict[str, dict] = {}
+        all_sensors: Dict[str, SensorReading] = {}
         for site_id in site_ids:
             sensor_page_url = f"{SENSOR_LIST_URL}?siteNbr={site_id}"
 

--- a/tests/session_reuse_test.py
+++ b/tests/session_reuse_test.py
@@ -16,6 +16,7 @@ from aioresponses import aioresponses
 
 from pyomnisense.omnisense import (
     Omnisense,
+    OmnisenseAuthError,
     LOGIN_URL,
     SITE_LIST_URL,
     SENSOR_LIST_URL,
@@ -124,9 +125,9 @@ async def test_login_replaces_credentials_atomically():
     a silent partial update that re-uses cached credentials of the
     *other* user."""
     omnisense = Omnisense()
-    with pytest.raises(Exception):
+    with pytest.raises(OmnisenseAuthError):
         await omnisense.login("alice", None)
-    with pytest.raises(Exception):
+    with pytest.raises(OmnisenseAuthError):
         await omnisense.login(None, "secret")
     await omnisense.close()
 
@@ -151,3 +152,20 @@ async def test_relogin_closes_old_session():
         assert first_session.closed, "previous session was leaked across re-login"
 
         await omnisense.close()
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_context_manager_closes_session():
+    """``async with Omnisense()`` should close the session on exit, even
+    when the block raises."""
+    with aioresponses() as m:
+        _mock_successful_login(m)
+
+        async with Omnisense() as omnisense:
+            assert await omnisense.login("user", "pass") is True
+            session = omnisense._session
+            assert session is not None and not session.closed
+
+        assert omnisense._session is None
+        assert session.closed


### PR DESCRIPTION
Follow-up to #5, working through more of the items from #4.

### Changes

- **Typed exception hierarchy (#14)** — `OmnisenseError` (base) and `OmnisenseAuthError` (auth / session problems). Replaces the `raise Exception(...)` calls so callers can `except OmnisenseAuthError` to retry only on real auth failures.
- **Async context manager (#13)** — `__aenter__` / `__aexit__` so callers can write `async with Omnisense() as o:` and have the underlying `ClientSession` closed automatically, including on errors.
- **TypedDict return shape (#16)** — `SensorReading` TypedDict; annotate `get_sensor_data`'s return as `Dict[str, SensorReading]`. Gives IDE autocomplete and mypy coverage to downstream code for free.
- **requires-python bump (#17)** — `>=3.7` (EOL since 2023) → `>=3.10`, with matching trove classifiers.
- **README polish (#28 + nit)** — fix the `your_username/pyomnisense.git` placeholder; show the new context-manager + typed-exception usage; document the transparent-relogin feature.
- Re-export `OmnisenseError` / `OmnisenseAuthError` / `SensorReading` from the package root.

### Version

Bumped to **0.2.0** because the python-version floor moved.

### Tests

- Tightened the partial-credentials test to assert `OmnisenseAuthError` specifically.
- Added `test_context_manager_closes_session` verifying the new `async with` path closes the session.
- `pytest -m offline` now reports **25 passed**.

Refs #4.