### PR TITLE
Test cleanup: shared fixtures, structural live assertions

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,112 @@
+"""Shared pytest fixtures for the offline test suite.
+
+Before this conftest existed, every test re-stamped ~30 lines of
+``aioresponses`` setup (login POST + dashboard GET + sample HTML loads).
+The fixtures below let each test focus on its actual subject - the call
+under test and the expected result.
+"""
+
+import os
+from typing import Dict
+
+import pytest
+from aioresponses import aioresponses
+
+from pyomnisense.omnisense import (
+    HOST_URL,
+    LOGIN_URL,
+    SENSOR_LIST_URL,
+    SITE_LIST_URL,
+    Omnisense,
+)
+
+
+SAMPLES_DIR = os.path.join(os.path.dirname(__file__), "samples")
+
+
+def _load_sample(name: str) -> str:
+    with open(os.path.join(SAMPLES_DIR, name), encoding="utf-8") as f:
+        return f.read()
+
+
+@pytest.fixture
+def sample_site_html() -> str:
+    return _load_sample("site_list.html")
+
+
+@pytest.fixture
+def sample_sensors_123456() -> str:
+    return _load_sample("sensor_123456.html")
+
+
+@pytest.fixture
+def sample_sensors_654321() -> str:
+    return _load_sample("sensor_654321.html")
+
+
+@pytest.fixture
+def all_sensors_html(sample_sensors_123456, sample_sensors_654321) -> Dict[str, str]:
+    """``{site_id: sensor_list_html}`` for both sample sites."""
+    return {
+        "123456": sample_sensors_123456,
+        "654321": sample_sensors_654321,
+    }
+
+
+@pytest.fixture
+def register_login():
+    """Returns a helper that registers one successful login round-trip
+    (POST /user_login.asp -> 302, GET /site_select.asp -> dashboard) on a
+    given ``aioresponses`` mock."""
+
+    def _register(
+        m: aioresponses,
+        set_cookie: str = "ASP.NET_SessionId=abc123; Path=/; HttpOnly",
+    ) -> None:
+        m.post(
+            LOGIN_URL,
+            status=302,
+            headers={"Set-Cookie": set_cookie, "Location": "/site_select.asp"},
+            body="",
+        )
+        m.get(
+            f"{HOST_URL}/site_select.asp",
+            status=200,
+            body="Welcome to your dashboard",
+        )
+
+    return _register
+
+
+@pytest.fixture
+def register_sensors():
+    """Returns a helper that registers the per-site sensor-list endpoints
+    on a given ``aioresponses`` mock for each ``{site_id: html}`` entry."""
+
+    def _register(m: aioresponses, html_by_site_id: Dict[str, str]) -> None:
+        for site_id, html in html_by_site_id.items():
+            m.get(
+                f"{SENSOR_LIST_URL}?siteNbr={site_id}",
+                status=200,
+                body=html,
+            )
+
+    return _register
+
+
+@pytest.fixture
+async def logged_in(register_login):
+    """Yields ``(omnisense, mock)`` with login already done.
+
+    The caller can keep registering additional GET endpoints on ``mock``
+    before invoking data methods on ``omnisense``. Session is closed on
+    teardown.
+    """
+    with aioresponses() as m:
+        register_login(m)
+        omnisense = Omnisense()
+        assert await omnisense.login("testuser", "testpass") is True
+        try:
+            yield omnisense, m
+        finally:
+            await omnisense.close()

--- a/tests/live_test.py
+++ b/tests/live_test.py
@@ -1,50 +1,63 @@
-import pytest
+"""End-to-end test against the real omnisense.com service.
+
+Skipped unless ``OMNISENSE_USERNAME`` / ``OMNISENSE_PASSWORD`` are set
+(typically loaded from a ``.env`` file or supplied by the CI job).
+
+The assertions deliberately avoid account-specific values so that any
+collaborator with valid Omnisense credentials can run this test against
+*their* account and have it pass.
+"""
+
 import os
-from pyomnisense import Omnisense
+
+import pytest
 from dotenv import load_dotenv
 
-# Load environment variables from .env file
+from pyomnisense import Omnisense
+
 load_dotenv()
+
+
+EXPECTED_SENSOR_KEYS = {
+    "description",
+    "last_activity",
+    "status",
+    "temperature",
+    "relative_humidity",
+    "absolute_humidity",
+    "dew_point",
+    "wood_pct",
+    "battery_voltage",
+    "sensor_type",
+    "sensor_id",
+    "site_name",
+}
+
 
 @pytest.mark.live
 @pytest.mark.skipif(
     not os.getenv("OMNISENSE_USERNAME") or not os.getenv("OMNISENSE_PASSWORD"),
-    reason="OMNISENSE_USERNAME or OMNISENSE_PASSWORD environment variable not set"
+    reason="OMNISENSE_USERNAME or OMNISENSE_PASSWORD environment variable not set",
 )
 @pytest.mark.asyncio
 async def test_live_login_and_fetch_data():
-    omnisense = Omnisense()
-    username = os.getenv("OMNISENSE_USERNAME")
-    password = os.getenv("OMNISENSE_PASSWORD")
+    username = os.environ["OMNISENSE_USERNAME"]
+    password = os.environ["OMNISENSE_PASSWORD"]
 
-    assert username is not None, "OMNISENSE_USERNAME is not set"
-    assert password is not None, "OMNISENSE_PASSWORD is not set"
+    async with Omnisense() as omnisense:
+        assert await omnisense.login(username, password) is True, "Login failed"
 
-    result = await omnisense.login(username, password)
-    assert result is True, "Login failed"
+        sites = await omnisense.get_site_list()
+        assert isinstance(sites, dict)
+        assert sites, "Account should have at least one site"
 
-    sites = await omnisense.get_site_list()
-    expected_result = {'119345': 'Home', '143554': 'BDL'}
-    assert sites == expected_result
+        sensor_data = await omnisense.get_sensor_data()
+        assert isinstance(sensor_data, dict)
+        assert sensor_data, "Account should have at least one sensor"
 
-    sensor_data = await omnisense.get_sensor_data()
-
-    #verify there are 14 sensors and that the correct keys are there for each sensor but ignore the values
-    assert len(sensor_data) == 14
-    for key, data in sensor_data.items():
-        for key in data.keys():
-            assert len(data.keys()) == 12
-            assert 'description' in data
-            assert 'last_activity' in data
-            assert 'status' in data
-            assert 'temperature' in data
-            assert 'relative_humidity' in data
-            assert 'absolute_humidity' in data
-            assert 'dew_point' in data
-            assert 'wood_pct' in data
-            assert 'battery_voltage' in data
-            assert 'sensor_type' in data
-            assert 'sensor_id' in data
-            assert 'site_name' in data
-
-    await omnisense.close()
+        for sensor_id, reading in sensor_data.items():
+            assert sensor_id, "sensor_id must be non-empty"
+            assert set(reading.keys()) == EXPECTED_SENSOR_KEYS, (
+                f"sensor {sensor_id} has unexpected key set: "
+                f"{set(reading.keys()) ^ EXPECTED_SENSOR_KEYS}"
+            )

--- a/tests/login_test.py
+++ b/tests/login_test.py
@@ -1,94 +1,74 @@
-import pytest
+"""Tests for ``Omnisense.login`` (success, failure modes, close)."""
+
 import aiohttp
+import pytest
 from aioresponses import aioresponses
-from pyomnisense.omnisense import Omnisense, LOGIN_URL, HOST_URL
+
+from pyomnisense.omnisense import (
+    HOST_URL,
+    LOGIN_URL,
+    Omnisense,
+    OmnisenseAuthError,
+)
+
 
 @pytest.mark.offline
 @pytest.mark.asyncio
-async def test_successful_login():
-    omnisense = Omnisense()
-    username = "testuser"
-    password = "testpass"
-
-    # Simulate the Set-Cookie and Location headers in the login POST response
-    set_cookie_value = "ASP.NET_SessionId=abc123; Path=/; HttpOnly"
-    redirect_location = "/site_select.asp"
-
+async def test_successful_login(register_login):
     with aioresponses() as m:
-        # Mock the POST to LOGIN_URL with Set-Cookie and Location headers
-        m.post(
-            LOGIN_URL,
-            status=302,
-            headers={
-                "Set-Cookie": set_cookie_value,
-                "Location": redirect_location,
-            },
-            body="",
-        )
-        # Mock the GET to the redirect location with the manual Cookie header
-        m.get(
-            f"{HOST_URL}{redirect_location}",
-            status=200,
-            body="Welcome to your dashboard",
-        )
-
-        result = await omnisense.login(username, password)
-        assert result is True
+        register_login(m)
+        omnisense = Omnisense()
+        assert await omnisense.login("user", "pass") is True
         await omnisense.close()
+
 
 @pytest.mark.offline
 @pytest.mark.asyncio
 async def test_failed_login_response_status():
-    omnisense = Omnisense()
-    username = "testuser"
-    password = "wrongpass"
-    # Simulate a failed login with non-200 status.
+    """A non-redirect / non-200 status on the login POST is treated as a
+    failure (no Location header is supplied)."""
     with aioresponses() as m:
         m.post(LOGIN_URL, status=401, body="Unauthorized")
-        result = await omnisense.login(username, password)
+        omnisense = Omnisense()
+        assert await omnisense.login("user", "wrong") is False
         await omnisense.close()
-        assert result is False
+
 
 @pytest.mark.offline
 @pytest.mark.asyncio
-async def test_failed_login_redirect_to_signin():
-    omnisense = Omnisense()
-    username = "testuser"
-    password = "wrongpass"
-    # Simulate a failed login: POST returns 302 redirecting back to LOGIN_URL
-    set_cookie_value = "userPNSToken=login+failed; Path=/"
-    redirect_location = "/user_login.asp"
-
+async def test_failed_login_redirect_with_failure_cookie():
+    """When the server hands us a ``userPNSToken=login+failed`` cookie we
+    must abort the login flow before following the redirect."""
     with aioresponses() as m:
         m.post(
             LOGIN_URL,
             status=302,
             headers={
-                "Set-Cookie": set_cookie_value,
+                "Set-Cookie": "userPNSToken=login+failed; Path=/",
                 "Location": "/user_login.asp",
             },
             body="",
         )
-
-        result = await omnisense.login(username, password)
+        omnisense = Omnisense()
+        assert await omnisense.login("user", "wrong") is False
         await omnisense.close()
-        assert result is False
+
 
 @pytest.mark.offline
 @pytest.mark.asyncio
-async def test_no_credentials_provided():
+async def test_no_credentials_raises_typed_error():
     omnisense = Omnisense()
-    # Calling login without credentials should raise an Exception.
-    with pytest.raises(Exception) as excinfo:
+    with pytest.raises(OmnisenseAuthError, match="No username or password"):
         await omnisense.login()
-    assert "No username or password provided." in str(excinfo.value)
     await omnisense.close()
 
+
 @pytest.mark.offline
 @pytest.mark.asyncio
-async def test_close_session():
+async def test_close_idempotent_and_clears_session():
     omnisense = Omnisense()
-    # Manually create an aiohttp session to simulate an active session.
     omnisense._session = aiohttp.ClientSession()
     await omnisense.close()
     assert omnisense._session is None
+    # second close must not raise
+    await omnisense.close()

--- a/tests/sensor_data_test.py
+++ b/tests/sensor_data_test.py
@@ -1,722 +1,171 @@
-import os
+"""Tests for ``Omnisense.get_sensor_data``.
+
+Each test sets up the *minimum* extra mocks it needs on top of the
+``logged_in`` fixture (which already supplied a working login), invokes
+``get_sensor_data`` with the variation under test, and asserts on the
+expected projection of ``ALL_SENSORS``.
+"""
+
 import pytest
-from aioresponses import aioresponses
-from pyomnisense.omnisense import Omnisense, LOGIN_URL, SITE_LIST_URL, SENSOR_LIST_URL, HOST_URL
+
+from pyomnisense.omnisense import SITE_LIST_URL
+
+
+# Canonical "everything" result, computed by parsing the two sample
+# sensor_*.html files. Individual tests slice this dict to express the
+# expected result of filtering by site or sensor.
+ALL_SENSORS = {
+    "2A000001": {"description": "Dining Room",         "last_activity": "24-12-30 10:57:44", "status": "A", "temperature": 25.1, "relative_humidity": "39.0", "absolute_humidity": "7.7", "dew_point": "10.2", "wood_pct": "7.2",  "battery_voltage": "3.4", "sensor_type": "S-11",  "sensor_id": "2A000001", "site_name": "MySite"},
+    "2A000002": {"description": "Basement",            "last_activity": "24-12-30 10:59:04", "status": "A", "temperature": 29.2, "relative_humidity": "30.4", "absolute_humidity": "7.7", "dew_point": "10.1", "wood_pct": "6.9",  "battery_voltage": "3.4", "sensor_type": "S-11",  "sensor_id": "2A000002", "site_name": "MySite"},
+    "2A000003": {"description": "Gateway",             "last_activity": "24-12-22 10:55:33", "status": "A", "temperature": 11.8, "relative_humidity": "78.4", "absolute_humidity": "6.8", "dew_point": "8.3",  "wood_pct": "13.0", "battery_voltage": "3.1", "sensor_type": "S-11",  "sensor_id": "2A000003", "site_name": "MySite"},
+    "2A000004": {"description": "Kitchen",             "last_activity": "24-12-30 10:59:40", "status": "A", "temperature": 24.7, "relative_humidity": "42.1", "absolute_humidity": "8.2", "dew_point": "11.0", "wood_pct": "7.8",  "battery_voltage": "3.4", "sensor_type": "S-11",  "sensor_id": "2A000004", "site_name": "MySite"},
+    "2A000005": {"description": "Laundry Room",        "last_activity": "24-12-22 10:51:17", "status": "A", "temperature": 14.4, "relative_humidity": "63.6", "absolute_humidity": "6.5", "dew_point": "7.6",  "wood_pct": "13.2", "battery_voltage": "3.2", "sensor_type": "S-11",  "sensor_id": "2A000005", "site_name": "MySite"},
+    "6BC00000": {"description": "<description not set>", "last_activity": "24-12-30 10:59:28", "status": "A", "temperature": 0.0,  "relative_humidity": "26",   "absolute_humidity": "0",   "dew_point": "60",   "wood_pct": "11",   "battery_voltage": "0.0", "sensor_type": "S-100", "sensor_id": "6BC00000", "site_name": "MySite"},
+    "2A001001": {"description": "Dining Room",         "last_activity": "24-12-30 10:57:44", "status": "A", "temperature": 25.1, "relative_humidity": "39.0", "absolute_humidity": "7.7", "dew_point": "10.2", "wood_pct": "7.2",  "battery_voltage": "3.4", "sensor_type": "S-11",  "sensor_id": "2A001001", "site_name": "FirstSite"},
+    "2A001002": {"description": "Basement",            "last_activity": "24-12-30 10:59:04", "status": "A", "temperature": 29.2, "relative_humidity": "30.4", "absolute_humidity": "7.7", "dew_point": "10.1", "wood_pct": "6.9",  "battery_voltage": "3.4", "sensor_type": "S-11",  "sensor_id": "2A001002", "site_name": "FirstSite"},
+    "2A001003": {"description": "Gateway",             "last_activity": "24-12-22 10:55:33", "status": "A", "temperature": 11.8, "relative_humidity": "78.4", "absolute_humidity": "6.8", "dew_point": "8.3",  "wood_pct": "13.0", "battery_voltage": "3.1", "sensor_type": "S-11",  "sensor_id": "2A001003", "site_name": "FirstSite"},
+    "2A001004": {"description": "Kitchen",             "last_activity": "24-12-30 10:59:40", "status": "A", "temperature": 24.7, "relative_humidity": "42.1", "absolute_humidity": "8.2", "dew_point": "11.0", "wood_pct": "7.8",  "battery_voltage": "3.4", "sensor_type": "S-11",  "sensor_id": "2A001004", "site_name": "FirstSite"},
+    "2A001005": {"description": "Laundry Room",        "last_activity": "24-12-22 10:51:17", "status": "A", "temperature": 14.4, "relative_humidity": "63.6", "absolute_humidity": "6.5", "dew_point": "7.6",  "wood_pct": "13.2", "battery_voltage": "3.2", "sensor_type": "S-11",  "sensor_id": "2A001005", "site_name": "FirstSite"},
+}
+
+SITE_123456_IDS = {sid for sid, info in ALL_SENSORS.items() if info["site_name"] == "MySite"}
+SITE_654321_IDS = {sid for sid, info in ALL_SENSORS.items() if info["site_name"] == "FirstSite"}
+
+
+def _subset(*sensor_ids):
+    return {sid: ALL_SENSORS[sid] for sid in sensor_ids}
+
 
 @pytest.mark.offline
 @pytest.mark.asyncio
-async def test_get_sensor_data_no_args():
-    # Load sample HTML content for the site list and sensor list from local files.
-    site_file_path = os.path.join(os.path.dirname(__file__), "samples", "site_list.html")
-    site_123456_sensors_file_path = os.path.join(os.path.dirname(__file__), "samples", "sensor_123456.html")
-    site_654321_sensors_file_path = os.path.join(os.path.dirname(__file__), "samples", "sensor_654321.html")
-    
-    with open(site_file_path, "r", encoding="utf-8") as f:
-        site_html = f.read()
-    
-    with open(site_123456_sensors_file_path, "r", encoding="utf-8") as f:
-        site_123456_sensors_html = f.read()
-        
-    with open(site_654321_sensors_file_path, "r", encoding="utf-8") as f:
-        site_654321_sensors_html = f.read()        
-    
-    omnisense = Omnisense()
-    
-    set_cookie_value = "ASP.NET_SessionId=abc123; Path=/; HttpOnly"
-    redirect_location = "/site_select.asp"
+async def test_no_args_returns_all_sensors_across_all_sites(
+    logged_in, sample_site_html, all_sensors_html, register_sensors
+):
+    omnisense, m = logged_in
+    m.get(SITE_LIST_URL, status=200, body=sample_site_html)
+    register_sensors(m, all_sensors_html)
 
-    # Use aioresponses context to fake all external HTTP calls.
-    with aioresponses() as m:
-        # Mock the POST to LOGIN_URL with Set-Cookie and Location headers
-        m.post(
-            LOGIN_URL,
-            status=302,
-            headers={
-                "Set-Cookie": set_cookie_value,
-                "Location": redirect_location,
-            },
-            body="",
-        )
-        # Mock the GET to the redirect location with the manual Cookie header
-        m.get(
-            f"{HOST_URL}{redirect_location}",
-            status=200,
-            body="Welcome to your dashboard",
-        )
-        
-        # Call login, which hits the faked LOGIN_URL.
-        login_result = await omnisense.login("testuser", "testpass")
-        assert login_result is True
-        
-        # Call get_site_list to hit the faked SITE_LIST_URL and obtain the site dictionary.
-        # Fake site list GET request.
-        m.get(SITE_LIST_URL, status=200, body=site_html)
-        
-        # Construct expected sensor URL based on first site's number.
-        site_123456_url = f"{SENSOR_LIST_URL}?siteNbr=123456"
-        # Fake sensor list GET request with the sample sensor HTML.
-        m.get(site_123456_url, status=200, body=site_123456_sensors_html)
-                
-        site_654321_url = f"{SENSOR_LIST_URL}?siteNbr=654321"
-        # Fake sensor list GET request with the sample sensor HTML.
-        m.get(site_654321_url, status=200, body=site_654321_sensors_html)
+    assert await omnisense.get_sensor_data() == ALL_SENSORS
 
-        sensor_result = await omnisense.get_sensor_data()
-        
-        # Define the expected sensor result (adjust as necessary based on your parsing logic).
-        expected_sensor_result = {
-          '2A000001': {'description': 'Dining Room', 'last_activity': '24-12-30 10:57:44', 'status': 'A', 'temperature': 25.1, 'relative_humidity': '39.0', 'absolute_humidity': '7.7', 'dew_point': '10.2', 'wood_pct': '7.2', 'battery_voltage': '3.4', 'sensor_type': 'S-11', 'sensor_id': '2A000001', 'site_name': 'MySite'}, 
-          '2A000002': {'description': 'Basement', 'last_activity': '24-12-30 10:59:04', 'status': 'A', 'temperature': 29.2, 'relative_humidity': '30.4', 'absolute_humidity': '7.7', 'dew_point': '10.1', 'wood_pct': '6.9', 'battery_voltage': '3.4', 'sensor_type': 'S-11', 'sensor_id': '2A000002', 'site_name': 'MySite'}, 
-          '2A000003': {'description': 'Gateway', 'last_activity': '24-12-22 10:55:33', 'status': 'A', 'temperature': 11.8, 'relative_humidity': '78.4', 'absolute_humidity': '6.8', 'dew_point': '8.3', 'wood_pct': '13.0', 'battery_voltage': '3.1', 'sensor_type': 'S-11', 'sensor_id': '2A000003', 'site_name': 'MySite'}, 
-          '2A000004': {'description': 'Kitchen', 'last_activity': '24-12-30 10:59:40', 'status': 'A', 'temperature': 24.7, 'relative_humidity': '42.1', 'absolute_humidity': '8.2', 'dew_point': '11.0', 'wood_pct': '7.8', 'battery_voltage': '3.4', 'sensor_type': 'S-11', 'sensor_id': '2A000004', 'site_name': 'MySite'}, 
-          '2A000005': {'description': 'Laundry Room', 'last_activity': '24-12-22 10:51:17', 'status': 'A', 'temperature': 14.4, 'relative_humidity': '63.6', 'absolute_humidity': '6.5', 'dew_point': '7.6', 'wood_pct': '13.2', 'battery_voltage': '3.2', 'sensor_type': 'S-11', 'sensor_id': '2A000005', 'site_name': 'MySite'},
-          '6BC00000': {'description': '<description not set>', 'last_activity': '24-12-30 10:59:28', 'status': 'A', 'temperature': 0.0, 'relative_humidity': '26', 'absolute_humidity': '0', 'dew_point': '60', 'wood_pct': '11', 'battery_voltage': '0.0', 'sensor_type': 'S-100', 'sensor_id': '6BC00000', 'site_name': 'MySite'}, 
-          '2A001001': {'description': 'Dining Room', 'last_activity': '24-12-30 10:57:44', 'status': 'A', 'temperature': 25.1, 'relative_humidity': '39.0', 'absolute_humidity': '7.7', 'dew_point': '10.2', 'wood_pct': '7.2', 'battery_voltage': '3.4', 'sensor_type': 'S-11', 'sensor_id': '2A001001', 'site_name': 'FirstSite'}, 
-          '2A001002': {'description': 'Basement', 'last_activity': '24-12-30 10:59:04', 'status': 'A', 'temperature': 29.2, 'relative_humidity': '30.4', 'absolute_humidity': '7.7', 'dew_point': '10.1', 'wood_pct': '6.9', 'battery_voltage': '3.4', 'sensor_type': 'S-11', 'sensor_id': '2A001002', 'site_name': 'FirstSite'}, 
-          '2A001003': {'description': 'Gateway', 'last_activity': '24-12-22 10:55:33', 'status': 'A', 'temperature': 11.8, 'relative_humidity': '78.4', 'absolute_humidity': '6.8', 'dew_point': '8.3', 'wood_pct': '13.0', 'battery_voltage': '3.1', 'sensor_type': 'S-11', 'sensor_id': '2A001003', 'site_name': 'FirstSite'}, 
-          '2A001004': {'description': 'Kitchen', 'last_activity': '24-12-30 10:59:40', 'status': 'A', 'temperature': 24.7, 'relative_humidity': '42.1', 'absolute_humidity': '8.2', 'dew_point': '11.0', 'wood_pct': '7.8', 'battery_voltage': '3.4', 'sensor_type': 'S-11', 'sensor_id': '2A001004', 'site_name': 'FirstSite'}, 
-          '2A001005': {'description': 'Laundry Room', 'last_activity': '24-12-22 10:51:17', 'status': 'A', 'temperature': 14.4, 'relative_humidity': '63.6', 'absolute_humidity': '6.5', 'dew_point': '7.6', 'wood_pct': '13.2', 'battery_voltage': '3.2', 'sensor_type': 'S-11', 'sensor_id': '2A001005', 'site_name': 'FirstSite'}
-          }
-        assert sensor_result == expected_sensor_result
-        
-        # Close the session to clean up.
-        await omnisense.close()
 
 @pytest.mark.offline
 @pytest.mark.asyncio
-async def test_get_sensor_data_pass_site_id_dict():
-    # Load sample HTML content for the site list and sensor list from local files.
-    site_file_path = os.path.join(os.path.dirname(__file__), "samples", "site_list.html")
-    site_123456_sensors_file_path = os.path.join(os.path.dirname(__file__), "samples", "sensor_123456.html")
-    site_654321_sensors_file_path = os.path.join(os.path.dirname(__file__), "samples", "sensor_654321.html")
-    
-    with open(site_file_path, "r", encoding="utf-8") as f:
-        site_html = f.read()
-    
-    with open(site_123456_sensors_file_path, "r", encoding="utf-8") as f:
-        site_123456_sensors_html = f.read()
-        
-    with open(site_654321_sensors_file_path, "r", encoding="utf-8") as f:
-        site_654321_sensors_html = f.read()        
-    
-    omnisense = Omnisense()
-    
-    set_cookie_value = "ASP.NET_SessionId=abc123; Path=/; HttpOnly"
-    redirect_location = "/site_select.asp"
+async def test_pass_site_id_dict(
+    logged_in, sample_site_html, all_sensors_html, register_sensors
+):
+    omnisense, m = logged_in
+    m.get(SITE_LIST_URL, status=200, body=sample_site_html)
+    register_sensors(m, all_sensors_html)
 
-    # Use aioresponses context to fake all external HTTP calls.
-    with aioresponses() as m:
-        # Mock the POST to LOGIN_URL with Set-Cookie and Location headers
-        m.post(
-            LOGIN_URL,
-            status=302,
-            headers={
-                "Set-Cookie": set_cookie_value,
-                "Location": redirect_location,
-            },
-            body="",
-        )
-        # Mock the GET to the redirect location with the manual Cookie header
-        m.get(
-            f"{HOST_URL}{redirect_location}",
-            status=200,
-            body="Welcome to your dashboard",
-        )
-        
-        # Call login, which hits the faked LOGIN_URL.
-        login_result = await omnisense.login("testuser", "testpass")
-        assert login_result is True
-        
-        # Call get_site_list to hit the faked SITE_LIST_URL and obtain the site dictionary.
-        # Fake site list GET request.
-        m.get(SITE_LIST_URL, status=200, body=site_html)
-        
-        # Construct expected sensor URL based on first site's number.
-        site_123456_url = f"{SENSOR_LIST_URL}?siteNbr=123456"
-        # Fake sensor list GET request with the sample sensor HTML.
-        m.get(site_123456_url, status=200, body=site_123456_sensors_html)
-                
-        site_654321_url = f"{SENSOR_LIST_URL}?siteNbr=654321"
-        # Fake sensor list GET request with the sample sensor HTML.
-        m.get(site_654321_url, status=200, body=site_654321_sensors_html)
-        
-        site_ids = await omnisense.get_site_list()
+    site_ids = await omnisense.get_site_list()
+    assert await omnisense.get_sensor_data(site_ids) == ALL_SENSORS
 
-        sensor_result = await omnisense.get_sensor_data(site_ids)
-        
-        # Define the expected sensor result (adjust as necessary based on your parsing logic).
-        expected_sensor_result = {
-          '2A000001': {'description': 'Dining Room', 'last_activity': '24-12-30 10:57:44', 'status': 'A', 'temperature': 25.1, 'relative_humidity': '39.0', 'absolute_humidity': '7.7', 'dew_point': '10.2', 'wood_pct': '7.2', 'battery_voltage': '3.4', 'sensor_type': 'S-11', 'sensor_id': '2A000001', 'site_name': 'MySite'}, 
-          '2A000002': {'description': 'Basement', 'last_activity': '24-12-30 10:59:04', 'status': 'A', 'temperature': 29.2, 'relative_humidity': '30.4', 'absolute_humidity': '7.7', 'dew_point': '10.1', 'wood_pct': '6.9', 'battery_voltage': '3.4', 'sensor_type': 'S-11', 'sensor_id': '2A000002', 'site_name': 'MySite'}, 
-          '2A000003': {'description': 'Gateway', 'last_activity': '24-12-22 10:55:33', 'status': 'A', 'temperature': 11.8, 'relative_humidity': '78.4', 'absolute_humidity': '6.8', 'dew_point': '8.3', 'wood_pct': '13.0', 'battery_voltage': '3.1', 'sensor_type': 'S-11', 'sensor_id': '2A000003', 'site_name': 'MySite'}, 
-          '2A000004': {'description': 'Kitchen', 'last_activity': '24-12-30 10:59:40', 'status': 'A', 'temperature': 24.7, 'relative_humidity': '42.1', 'absolute_humidity': '8.2', 'dew_point': '11.0', 'wood_pct': '7.8', 'battery_voltage': '3.4', 'sensor_type': 'S-11', 'sensor_id': '2A000004', 'site_name': 'MySite'}, 
-          '2A000005': {'description': 'Laundry Room', 'last_activity': '24-12-22 10:51:17', 'status': 'A', 'temperature': 14.4, 'relative_humidity': '63.6', 'absolute_humidity': '6.5', 'dew_point': '7.6', 'wood_pct': '13.2', 'battery_voltage': '3.2', 'sensor_type': 'S-11', 'sensor_id': '2A000005', 'site_name': 'MySite'},
-          '6BC00000': {'description': '<description not set>', 'last_activity': '24-12-30 10:59:28', 'status': 'A', 'temperature': 0.0, 'relative_humidity': '26', 'absolute_humidity': '0', 'dew_point': '60', 'wood_pct': '11', 'battery_voltage': '0.0', 'sensor_type': 'S-100', 'sensor_id': '6BC00000', 'site_name': 'MySite'}, 
-          '2A001001': {'description': 'Dining Room', 'last_activity': '24-12-30 10:57:44', 'status': 'A', 'temperature': 25.1, 'relative_humidity': '39.0', 'absolute_humidity': '7.7', 'dew_point': '10.2', 'wood_pct': '7.2', 'battery_voltage': '3.4', 'sensor_type': 'S-11', 'sensor_id': '2A001001', 'site_name': 'FirstSite'}, 
-          '2A001002': {'description': 'Basement', 'last_activity': '24-12-30 10:59:04', 'status': 'A', 'temperature': 29.2, 'relative_humidity': '30.4', 'absolute_humidity': '7.7', 'dew_point': '10.1', 'wood_pct': '6.9', 'battery_voltage': '3.4', 'sensor_type': 'S-11', 'sensor_id': '2A001002', 'site_name': 'FirstSite'}, 
-          '2A001003': {'description': 'Gateway', 'last_activity': '24-12-22 10:55:33', 'status': 'A', 'temperature': 11.8, 'relative_humidity': '78.4', 'absolute_humidity': '6.8', 'dew_point': '8.3', 'wood_pct': '13.0', 'battery_voltage': '3.1', 'sensor_type': 'S-11', 'sensor_id': '2A001003', 'site_name': 'FirstSite'}, 
-          '2A001004': {'description': 'Kitchen', 'last_activity': '24-12-30 10:59:40', 'status': 'A', 'temperature': 24.7, 'relative_humidity': '42.1', 'absolute_humidity': '8.2', 'dew_point': '11.0', 'wood_pct': '7.8', 'battery_voltage': '3.4', 'sensor_type': 'S-11', 'sensor_id': '2A001004', 'site_name': 'FirstSite'}, 
-          '2A001005': {'description': 'Laundry Room', 'last_activity': '24-12-22 10:51:17', 'status': 'A', 'temperature': 14.4, 'relative_humidity': '63.6', 'absolute_humidity': '6.5', 'dew_point': '7.6', 'wood_pct': '13.2', 'battery_voltage': '3.2', 'sensor_type': 'S-11', 'sensor_id': '2A001005', 'site_name': 'FirstSite'}
-          }
-        assert sensor_result == expected_sensor_result
-        
-        # Close the session to clean up.
-        await omnisense.close()
-        
-@pytest.mark.offline        
+
+@pytest.mark.offline
 @pytest.mark.asyncio
-async def test_get_sensor_data_pass_site_id_list():
-    # Load sample HTML content for the site list and sensor list from local files.
-    site_file_path = os.path.join(os.path.dirname(__file__), "samples", "site_list.html")
-    site_123456_sensors_file_path = os.path.join(os.path.dirname(__file__), "samples", "sensor_123456.html")
-    site_654321_sensors_file_path = os.path.join(os.path.dirname(__file__), "samples", "sensor_654321.html")
-    
-    with open(site_file_path, "r", encoding="utf-8") as f:
-        site_html = f.read()
-    
-    with open(site_123456_sensors_file_path, "r", encoding="utf-8") as f:
-        site_123456_sensors_html = f.read()
-        
-    with open(site_654321_sensors_file_path, "r", encoding="utf-8") as f:
-        site_654321_sensors_html = f.read()        
-    
-    omnisense = Omnisense()
-    
-    set_cookie_value = "ASP.NET_SessionId=abc123; Path=/; HttpOnly"
-    redirect_location = "/site_select.asp"
+async def test_pass_site_id_list(
+    logged_in, sample_site_html, all_sensors_html, register_sensors
+):
+    omnisense, m = logged_in
+    m.get(SITE_LIST_URL, status=200, body=sample_site_html)
+    register_sensors(m, all_sensors_html)
 
-    # Use aioresponses context to fake all external HTTP calls.
-    with aioresponses() as m:
-        # Mock the POST to LOGIN_URL with Set-Cookie and Location headers
-        m.post(
-            LOGIN_URL,
-            status=302,
-            headers={
-                "Set-Cookie": set_cookie_value,
-                "Location": redirect_location,
-            },
-            body="",
-        )
-        # Mock the GET to the redirect location with the manual Cookie header
-        m.get(
-            f"{HOST_URL}{redirect_location}",
-            status=200,
-            body="Welcome to your dashboard",
-        )
-        
-        # Call login, which hits the faked LOGIN_URL.
-        login_result = await omnisense.login("testuser", "testpass")
-        assert login_result is True
-        
-        # Call get_site_list to hit the faked SITE_LIST_URL and obtain the site dictionary.
-        # Fake site list GET request.
-        m.get(SITE_LIST_URL, status=200, body=site_html)
-        
-        # Construct expected sensor URL based on first site's number.
-        site_123456_url = f"{SENSOR_LIST_URL}?siteNbr=123456"
-        # Fake sensor list GET request with the sample sensor HTML.
-        m.get(site_123456_url, status=200, body=site_123456_sensors_html)
-                
-        site_654321_url = f"{SENSOR_LIST_URL}?siteNbr=654321"
-        # Fake sensor list GET request with the sample sensor HTML.
-        m.get(site_654321_url, status=200, body=site_654321_sensors_html)
-        
-        site_ids = await omnisense.get_site_list()
+    site_ids = await omnisense.get_site_list()
+    assert await omnisense.get_sensor_data(list(site_ids.keys())) == ALL_SENSORS
 
-        sensor_result = await omnisense.get_sensor_data(list(site_ids.keys()))
-        
-        # Define the expected sensor result (adjust as necessary based on your parsing logic).
-        expected_sensor_result = {
-          '2A000001': {'description': 'Dining Room', 'last_activity': '24-12-30 10:57:44', 'status': 'A', 'temperature': 25.1, 'relative_humidity': '39.0', 'absolute_humidity': '7.7', 'dew_point': '10.2', 'wood_pct': '7.2', 'battery_voltage': '3.4', 'sensor_type': 'S-11', 'sensor_id': '2A000001', 'site_name': 'MySite'}, 
-          '2A000002': {'description': 'Basement', 'last_activity': '24-12-30 10:59:04', 'status': 'A', 'temperature': 29.2, 'relative_humidity': '30.4', 'absolute_humidity': '7.7', 'dew_point': '10.1', 'wood_pct': '6.9', 'battery_voltage': '3.4', 'sensor_type': 'S-11', 'sensor_id': '2A000002', 'site_name': 'MySite'}, 
-          '2A000003': {'description': 'Gateway', 'last_activity': '24-12-22 10:55:33', 'status': 'A', 'temperature': 11.8, 'relative_humidity': '78.4', 'absolute_humidity': '6.8', 'dew_point': '8.3', 'wood_pct': '13.0', 'battery_voltage': '3.1', 'sensor_type': 'S-11', 'sensor_id': '2A000003', 'site_name': 'MySite'}, 
-          '2A000004': {'description': 'Kitchen', 'last_activity': '24-12-30 10:59:40', 'status': 'A', 'temperature': 24.7, 'relative_humidity': '42.1', 'absolute_humidity': '8.2', 'dew_point': '11.0', 'wood_pct': '7.8', 'battery_voltage': '3.4', 'sensor_type': 'S-11', 'sensor_id': '2A000004', 'site_name': 'MySite'}, 
-          '2A000005': {'description': 'Laundry Room', 'last_activity': '24-12-22 10:51:17', 'status': 'A', 'temperature': 14.4, 'relative_humidity': '63.6', 'absolute_humidity': '6.5', 'dew_point': '7.6', 'wood_pct': '13.2', 'battery_voltage': '3.2', 'sensor_type': 'S-11', 'sensor_id': '2A000005', 'site_name': 'MySite'},
-          '6BC00000': {'description': '<description not set>', 'last_activity': '24-12-30 10:59:28', 'status': 'A', 'temperature': 0.0, 'relative_humidity': '26', 'absolute_humidity': '0', 'dew_point': '60', 'wood_pct': '11', 'battery_voltage': '0.0', 'sensor_type': 'S-100', 'sensor_id': '6BC00000', 'site_name': 'MySite'}, 
-          '2A001001': {'description': 'Dining Room', 'last_activity': '24-12-30 10:57:44', 'status': 'A', 'temperature': 25.1, 'relative_humidity': '39.0', 'absolute_humidity': '7.7', 'dew_point': '10.2', 'wood_pct': '7.2', 'battery_voltage': '3.4', 'sensor_type': 'S-11', 'sensor_id': '2A001001', 'site_name': 'FirstSite'}, 
-          '2A001002': {'description': 'Basement', 'last_activity': '24-12-30 10:59:04', 'status': 'A', 'temperature': 29.2, 'relative_humidity': '30.4', 'absolute_humidity': '7.7', 'dew_point': '10.1', 'wood_pct': '6.9', 'battery_voltage': '3.4', 'sensor_type': 'S-11', 'sensor_id': '2A001002', 'site_name': 'FirstSite'}, 
-          '2A001003': {'description': 'Gateway', 'last_activity': '24-12-22 10:55:33', 'status': 'A', 'temperature': 11.8, 'relative_humidity': '78.4', 'absolute_humidity': '6.8', 'dew_point': '8.3', 'wood_pct': '13.0', 'battery_voltage': '3.1', 'sensor_type': 'S-11', 'sensor_id': '2A001003', 'site_name': 'FirstSite'}, 
-          '2A001004': {'description': 'Kitchen', 'last_activity': '24-12-30 10:59:40', 'status': 'A', 'temperature': 24.7, 'relative_humidity': '42.1', 'absolute_humidity': '8.2', 'dew_point': '11.0', 'wood_pct': '7.8', 'battery_voltage': '3.4', 'sensor_type': 'S-11', 'sensor_id': '2A001004', 'site_name': 'FirstSite'}, 
-          '2A001005': {'description': 'Laundry Room', 'last_activity': '24-12-22 10:51:17', 'status': 'A', 'temperature': 14.4, 'relative_humidity': '63.6', 'absolute_humidity': '6.5', 'dew_point': '7.6', 'wood_pct': '13.2', 'battery_voltage': '3.2', 'sensor_type': 'S-11', 'sensor_id': '2A001005', 'site_name': 'FirstSite'}
-          }
-        assert sensor_result == expected_sensor_result
-        
-        # Close the session to clean up.
-        await omnisense.close()
 
-@pytest.mark.offline        
+@pytest.mark.offline
 @pytest.mark.asyncio
-async def test_get_sensor_data_pass_single_site_id_string():
-    # Load sample HTML content for the site list and sensor list from local files.
-    site_file_path = os.path.join(os.path.dirname(__file__), "samples", "site_list.html")
-    site_123456_sensors_file_path = os.path.join(os.path.dirname(__file__), "samples", "sensor_123456.html")
-    site_654321_sensors_file_path = os.path.join(os.path.dirname(__file__), "samples", "sensor_654321.html")
-    
-    with open(site_file_path, "r", encoding="utf-8") as f:
-        site_html = f.read()
-    
-    with open(site_123456_sensors_file_path, "r", encoding="utf-8") as f:
-        site_123456_sensors_html = f.read()
-        
-    with open(site_654321_sensors_file_path, "r", encoding="utf-8") as f:
-        site_654321_sensors_html = f.read()        
-    
-    omnisense = Omnisense()
-    
-    set_cookie_value = "ASP.NET_SessionId=abc123; Path=/; HttpOnly"
-    redirect_location = "/site_select.asp"
+async def test_pass_single_site_id_string(
+    logged_in, all_sensors_html, register_sensors
+):
+    omnisense, m = logged_in
+    register_sensors(m, {"123456": all_sensors_html["123456"]})
 
-    # Use aioresponses context to fake all external HTTP calls.
-    with aioresponses() as m:
-        # Mock the POST to LOGIN_URL with Set-Cookie and Location headers
-        m.post(
-            LOGIN_URL,
-            status=302,
-            headers={
-                "Set-Cookie": set_cookie_value,
-                "Location": redirect_location,
-            },
-            body="",
-        )
-        # Mock the GET to the redirect location with the manual Cookie header
-        m.get(
-            f"{HOST_URL}{redirect_location}",
-            status=200,
-            body="Welcome to your dashboard",
-        )
-        
-        # Call login, which hits the faked LOGIN_URL.
-        login_result = await omnisense.login("testuser", "testpass")
-        assert login_result is True
-        
-        # Call get_site_list to hit the faked SITE_LIST_URL and obtain the site dictionary.
-        # Fake site list GET request.
-        m.get(SITE_LIST_URL, status=200, body=site_html)
-        
-        # Construct expected sensor URL based on first site's number.
-        site_123456_url = f"{SENSOR_LIST_URL}?siteNbr=123456"
-        # Fake sensor list GET request with the sample sensor HTML.
-        m.get(site_123456_url, status=200, body=site_123456_sensors_html)
-                
-        sensor_result = await omnisense.get_sensor_data("123456")
-        
-        # Define the expected sensor result (adjust as necessary based on your parsing logic).
-        expected_sensor_result = {
-          '2A000001': {'description': 'Dining Room', 'last_activity': '24-12-30 10:57:44', 'status': 'A', 'temperature': 25.1, 'relative_humidity': '39.0', 'absolute_humidity': '7.7', 'dew_point': '10.2', 'wood_pct': '7.2', 'battery_voltage': '3.4', 'sensor_type': 'S-11', 'sensor_id': '2A000001', 'site_name': 'MySite'}, 
-          '2A000002': {'description': 'Basement', 'last_activity': '24-12-30 10:59:04', 'status': 'A', 'temperature': 29.2, 'relative_humidity': '30.4', 'absolute_humidity': '7.7', 'dew_point': '10.1', 'wood_pct': '6.9', 'battery_voltage': '3.4', 'sensor_type': 'S-11', 'sensor_id': '2A000002', 'site_name': 'MySite'}, 
-          '2A000003': {'description': 'Gateway', 'last_activity': '24-12-22 10:55:33', 'status': 'A', 'temperature': 11.8, 'relative_humidity': '78.4', 'absolute_humidity': '6.8', 'dew_point': '8.3', 'wood_pct': '13.0', 'battery_voltage': '3.1', 'sensor_type': 'S-11', 'sensor_id': '2A000003', 'site_name': 'MySite'}, 
-          '2A000004': {'description': 'Kitchen', 'last_activity': '24-12-30 10:59:40', 'status': 'A', 'temperature': 24.7, 'relative_humidity': '42.1', 'absolute_humidity': '8.2', 'dew_point': '11.0', 'wood_pct': '7.8', 'battery_voltage': '3.4', 'sensor_type': 'S-11', 'sensor_id': '2A000004', 'site_name': 'MySite'}, 
-          '2A000005': {'description': 'Laundry Room', 'last_activity': '24-12-22 10:51:17', 'status': 'A', 'temperature': 14.4, 'relative_humidity': '63.6', 'absolute_humidity': '6.5', 'dew_point': '7.6', 'wood_pct': '13.2', 'battery_voltage': '3.2', 'sensor_type': 'S-11', 'sensor_id': '2A000005', 'site_name': 'MySite'},
-          '6BC00000': {'description': '<description not set>', 'last_activity': '24-12-30 10:59:28', 'status': 'A', 'temperature': 0.0, 'relative_humidity': '26', 'absolute_humidity': '0', 'dew_point': '60', 'wood_pct': '11', 'battery_voltage': '0.0', 'sensor_type': 'S-100', 'sensor_id': '6BC00000', 'site_name': 'MySite'}, 
-          }
-        assert sensor_result == expected_sensor_result
-        
-        # Close the session to clean up.
-        await omnisense.close()
-        
-@pytest.mark.offline        
+    result = await omnisense.get_sensor_data("123456")
+    assert result == _subset(*SITE_123456_IDS)
+
+
+@pytest.mark.offline
 @pytest.mark.asyncio
-async def test_get_sensor_data_single_sensor():
-    # Load sample HTML content for the site list and sensor list from local files.
-    site_file_path = os.path.join(os.path.dirname(__file__), "samples", "site_list.html")
-    site_123456_sensors_file_path = os.path.join(os.path.dirname(__file__), "samples", "sensor_123456.html")
-    site_654321_sensors_file_path = os.path.join(os.path.dirname(__file__), "samples", "sensor_654321.html")
-    
-    with open(site_file_path, "r", encoding="utf-8") as f:
-        site_html = f.read()
-    
-    with open(site_123456_sensors_file_path, "r", encoding="utf-8") as f:
-        site_123456_sensors_html = f.read()
-        
-    with open(site_654321_sensors_file_path, "r", encoding="utf-8") as f:
-        site_654321_sensors_html = f.read()        
-    
-    omnisense = Omnisense()
-    
-    set_cookie_value = "ASP.NET_SessionId=abc123; Path=/; HttpOnly"
-    redirect_location = "/site_select.asp"
+async def test_single_sensor_id_filter(
+    logged_in, sample_site_html, all_sensors_html, register_sensors
+):
+    omnisense, m = logged_in
+    m.get(SITE_LIST_URL, status=200, body=sample_site_html)
+    register_sensors(m, {"123456": all_sensors_html["123456"]})
 
-    # Use aioresponses context to fake all external HTTP calls.
-    with aioresponses() as m:
-        # Mock the POST to LOGIN_URL with Set-Cookie and Location headers
-        m.post(
-            LOGIN_URL,
-            status=302,
-            headers={
-                "Set-Cookie": set_cookie_value,
-                "Location": redirect_location,
-            },
-            body="",
-        )
-        # Mock the GET to the redirect location with the manual Cookie header
-        m.get(
-            f"{HOST_URL}{redirect_location}",
-            status=200,
-            body="Welcome to your dashboard",
-        )
-        
-        # Call login, which hits the faked LOGIN_URL.
-        login_result = await omnisense.login("testuser", "testpass")
-        assert login_result is True
-        
-        # Call get_site_list to hit the faked SITE_LIST_URL and obtain the site dictionary.
-        # Fake site list GET request.
-        m.get(SITE_LIST_URL, status=200, body=site_html)
-        
-        # Construct expected sensor URL based on first site's number.
-        site_123456_url = f"{SENSOR_LIST_URL}?siteNbr=123456"
-        # Fake sensor list GET request with the sample sensor HTML.
-        m.get(site_123456_url, status=200, body=site_123456_sensors_html)
-                
-        sensor_result = await omnisense.get_sensor_data(sensor_ids="2A000005")
-        
-        # Define the expected sensor result (adjust as necessary based on your parsing logic).
-        expected_sensor_result = {
-          '2A000005': {'description': 'Laundry Room', 'last_activity': '24-12-22 10:51:17', 'status': 'A', 'temperature': 14.4, 'relative_humidity': '63.6', 'absolute_humidity': '6.5', 'dew_point': '7.6', 'wood_pct': '13.2', 'battery_voltage': '3.2', 'sensor_type': 'S-11', 'sensor_id': '2A000005', 'site_name': 'MySite'},
-          }
-        assert sensor_result == expected_sensor_result
-        
-        # Close the session to clean up.
-        await omnisense.close()           
-        
-@pytest.mark.offline        
+    result = await omnisense.get_sensor_data(sensor_ids="2A000005")
+    assert result == _subset("2A000005")
+
+
+@pytest.mark.offline
 @pytest.mark.asyncio
-async def test_get_sensor_data_sensor_id_list():
-    # Load sample HTML content for the site list and sensor list from local files.
-    site_file_path = os.path.join(os.path.dirname(__file__), "samples", "site_list.html")
-    site_123456_sensors_file_path = os.path.join(os.path.dirname(__file__), "samples", "sensor_123456.html")
-    site_654321_sensors_file_path = os.path.join(os.path.dirname(__file__), "samples", "sensor_654321.html")
-    
-    with open(site_file_path, "r", encoding="utf-8") as f:
-        site_html = f.read()
-    
-    with open(site_123456_sensors_file_path, "r", encoding="utf-8") as f:
-        site_123456_sensors_html = f.read()
-        
-    with open(site_654321_sensors_file_path, "r", encoding="utf-8") as f:
-        site_654321_sensors_html = f.read()        
-    
-    omnisense = Omnisense()
-    
-    set_cookie_value = "ASP.NET_SessionId=abc123; Path=/; HttpOnly"
-    redirect_location = "/site_select.asp"
+async def test_sensor_id_list_single_site(
+    logged_in, sample_site_html, all_sensors_html, register_sensors
+):
+    omnisense, m = logged_in
+    m.get(SITE_LIST_URL, status=200, body=sample_site_html)
+    register_sensors(m, {"123456": all_sensors_html["123456"]})
 
-    # Use aioresponses context to fake all external HTTP calls.
-    with aioresponses() as m:
-        # Mock the POST to LOGIN_URL with Set-Cookie and Location headers
-        m.post(
-            LOGIN_URL,
-            status=302,
-            headers={
-                "Set-Cookie": set_cookie_value,
-                "Location": redirect_location,
-            },
-            body="",
-        )
-        # Mock the GET to the redirect location with the manual Cookie header
-        m.get(
-            f"{HOST_URL}{redirect_location}",
-            status=200,
-            body="Welcome to your dashboard",
-        )
-        
-        # Call login, which hits the faked LOGIN_URL.
-        login_result = await omnisense.login("testuser", "testpass")
-        assert login_result is True
-        
-        # Call get_site_list to hit the faked SITE_LIST_URL and obtain the site dictionary.
-        # Fake site list GET request.
-        m.get(SITE_LIST_URL, status=200, body=site_html)
-        
-        # Construct expected sensor URL based on first site's number.
-        site_123456_url = f"{SENSOR_LIST_URL}?siteNbr=123456"
-        # Fake sensor list GET request with the sample sensor HTML.
-        m.get(site_123456_url, status=200, body=site_123456_sensors_html)
-                
-        sensor_result = await omnisense.get_sensor_data(sensor_ids=["2A000001", "2A000003", "2A000005", "6BC00000"])
-        
-        # Define the expected sensor result (adjust as necessary based on your parsing logic).
-        expected_sensor_result = {
-          '2A000001': {'description': 'Dining Room', 'last_activity': '24-12-30 10:57:44', 'status': 'A', 'temperature': 25.1, 'relative_humidity': '39.0', 'absolute_humidity': '7.7', 'dew_point': '10.2', 'wood_pct': '7.2', 'battery_voltage': '3.4', 'sensor_type': 'S-11', 'sensor_id': '2A000001', 'site_name': 'MySite'}, 
-          '2A000003': {'description': 'Gateway', 'last_activity': '24-12-22 10:55:33', 'status': 'A', 'temperature': 11.8, 'relative_humidity': '78.4', 'absolute_humidity': '6.8', 'dew_point': '8.3', 'wood_pct': '13.0', 'battery_voltage': '3.1', 'sensor_type': 'S-11', 'sensor_id': '2A000003', 'site_name': 'MySite'}, 
-          '2A000005': {'description': 'Laundry Room', 'last_activity': '24-12-22 10:51:17', 'status': 'A', 'temperature': 14.4, 'relative_humidity': '63.6', 'absolute_humidity': '6.5', 'dew_point': '7.6', 'wood_pct': '13.2', 'battery_voltage': '3.2', 'sensor_type': 'S-11', 'sensor_id': '2A000005', 'site_name': 'MySite'},
-          '6BC00000': {'description': '<description not set>', 'last_activity': '24-12-30 10:59:28', 'status': 'A', 'temperature': 0.0, 'relative_humidity': '26', 'absolute_humidity': '0', 'dew_point': '60', 'wood_pct': '11', 'battery_voltage': '0.0', 'sensor_type': 'S-100', 'sensor_id': '6BC00000', 'site_name': 'MySite'}, 
-          }
-        assert sensor_result == expected_sensor_result
-        
-        # Close the session to clean up.
-        await omnisense.close()
-        
-@pytest.mark.offline        
+    result = await omnisense.get_sensor_data(
+        sensor_ids=["2A000001", "2A000003", "2A000005", "6BC00000"]
+    )
+    assert result == _subset("2A000001", "2A000003", "2A000005", "6BC00000")
+
+
+@pytest.mark.offline
 @pytest.mark.asyncio
-async def test_get_sensor_data_sensor_id_list_multiple_sites():
-    # Load sample HTML content for the site list and sensor list from local files.
-    site_file_path = os.path.join(os.path.dirname(__file__), "samples", "site_list.html")
-    site_123456_sensors_file_path = os.path.join(os.path.dirname(__file__), "samples", "sensor_123456.html")
-    site_654321_sensors_file_path = os.path.join(os.path.dirname(__file__), "samples", "sensor_654321.html")
-    
-    with open(site_file_path, "r", encoding="utf-8") as f:
-        site_html = f.read()
-    
-    with open(site_123456_sensors_file_path, "r", encoding="utf-8") as f:
-        site_123456_sensors_html = f.read()
-        
-    with open(site_654321_sensors_file_path, "r", encoding="utf-8") as f:
-        site_654321_sensors_html = f.read()        
-    
-    omnisense = Omnisense()
-    
-    set_cookie_value = "ASP.NET_SessionId=abc123; Path=/; HttpOnly"
-    redirect_location = "/site_select.asp"
+async def test_sensor_id_list_multiple_sites(
+    logged_in, sample_site_html, all_sensors_html, register_sensors
+):
+    omnisense, m = logged_in
+    m.get(SITE_LIST_URL, status=200, body=sample_site_html)
+    register_sensors(m, all_sensors_html)
 
-    # Use aioresponses context to fake all external HTTP calls.
-    with aioresponses() as m:
-        # Mock the POST to LOGIN_URL with Set-Cookie and Location headers
-        m.post(
-            LOGIN_URL,
-            status=302,
-            headers={
-                "Set-Cookie": set_cookie_value,
-                "Location": redirect_location,
-            },
-            body="",
-        )
-        # Mock the GET to the redirect location with the manual Cookie header
-        m.get(
-            f"{HOST_URL}{redirect_location}",
-            status=200,
-            body="Welcome to your dashboard",
-        )
-        
-        # Call login, which hits the faked LOGIN_URL.
-        login_result = await omnisense.login("testuser", "testpass")
-        assert login_result is True
-        
-        # Call get_site_list to hit the faked SITE_LIST_URL and obtain the site dictionary.
-        # Fake site list GET request.
-        m.get(SITE_LIST_URL, status=200, body=site_html)
-        
-        # Construct expected sensor URL based on first site's number.
-        site_123456_url = f"{SENSOR_LIST_URL}?siteNbr=123456"
-        # Fake sensor list GET request with the sample sensor HTML.
-        m.get(site_123456_url, status=200, body=site_123456_sensors_html)
-        
-        site_654321_url = f"{SENSOR_LIST_URL}?siteNbr=654321"
-        # Fake sensor list GET request with the sample sensor HTML.
-        m.get(site_654321_url, status=200, body=site_654321_sensors_html)        
-                
-        sensor_result = await omnisense.get_sensor_data(sensor_ids=["2A000002", "2A000003", "2A001002", "2A001005"])
-        
-        # Define the expected sensor result (adjust as necessary based on your parsing logic).
-        expected_sensor_result = {
-          '2A000002': {'description': 'Basement', 'last_activity': '24-12-30 10:59:04', 'status': 'A', 'temperature': 29.2, 'relative_humidity': '30.4', 'absolute_humidity': '7.7', 'dew_point': '10.1', 'wood_pct': '6.9', 'battery_voltage': '3.4', 'sensor_type': 'S-11', 'sensor_id': '2A000002', 'site_name': 'MySite'}, 
-          '2A000003': {'description': 'Gateway', 'last_activity': '24-12-22 10:55:33', 'status': 'A', 'temperature': 11.8, 'relative_humidity': '78.4', 'absolute_humidity': '6.8', 'dew_point': '8.3', 'wood_pct': '13.0', 'battery_voltage': '3.1', 'sensor_type': 'S-11', 'sensor_id': '2A000003', 'site_name': 'MySite'}, 
-          '2A001002': {'description': 'Basement', 'last_activity': '24-12-30 10:59:04', 'status': 'A', 'temperature': 29.2, 'relative_humidity': '30.4', 'absolute_humidity': '7.7', 'dew_point': '10.1', 'wood_pct': '6.9', 'battery_voltage': '3.4', 'sensor_type': 'S-11', 'sensor_id': '2A001002', 'site_name': 'FirstSite'}, 
-          '2A001005': {'description': 'Laundry Room', 'last_activity': '24-12-22 10:51:17', 'status': 'A', 'temperature': 14.4, 'relative_humidity': '63.6', 'absolute_humidity': '6.5', 'dew_point': '7.6', 'wood_pct': '13.2', 'battery_voltage': '3.2', 'sensor_type': 'S-11', 'sensor_id': '2A001005', 'site_name': 'FirstSite'}
-          }
-        assert sensor_result == expected_sensor_result
-        
-        # Close the session to clean up.
-        await omnisense.close()
-        
-@pytest.mark.offline        
+    result = await omnisense.get_sensor_data(
+        sensor_ids=["2A000002", "2A000003", "2A001002", "2A001005"]
+    )
+    assert result == _subset("2A000002", "2A000003", "2A001002", "2A001005")
+
+
+@pytest.mark.offline
 @pytest.mark.asyncio
-async def test_get_sensor_data_sensor_id_list_multiple_sites_with_some_unknown_sensor_ids():
-    # Load sample HTML content for the site list and sensor list from local files.
-    site_file_path = os.path.join(os.path.dirname(__file__), "samples", "site_list.html")
-    site_123456_sensors_file_path = os.path.join(os.path.dirname(__file__), "samples", "sensor_123456.html")
-    site_654321_sensors_file_path = os.path.join(os.path.dirname(__file__), "samples", "sensor_654321.html")
-    
-    with open(site_file_path, "r", encoding="utf-8") as f:
-        site_html = f.read()
-    
-    with open(site_123456_sensors_file_path, "r", encoding="utf-8") as f:
-        site_123456_sensors_html = f.read()
-        
-    with open(site_654321_sensors_file_path, "r", encoding="utf-8") as f:
-        site_654321_sensors_html = f.read()        
-    
-    omnisense = Omnisense()
-    
-    set_cookie_value = "ASP.NET_SessionId=abc123; Path=/; HttpOnly"
-    redirect_location = "/site_select.asp"
+async def test_sensor_id_list_with_some_unknown_ids(
+    logged_in, sample_site_html, all_sensors_html, register_sensors
+):
+    omnisense, m = logged_in
+    m.get(SITE_LIST_URL, status=200, body=sample_site_html)
+    register_sensors(m, all_sensors_html)
 
-    # Use aioresponses context to fake all external HTTP calls.
-    with aioresponses() as m:
-        # Mock the POST to LOGIN_URL with Set-Cookie and Location headers
-        m.post(
-            LOGIN_URL,
-            status=302,
-            headers={
-                "Set-Cookie": set_cookie_value,
-                "Location": redirect_location,
-            },
-            body="",
-        )
-        # Mock the GET to the redirect location with the manual Cookie header
-        m.get(
-            f"{HOST_URL}{redirect_location}",
-            status=200,
-            body="Welcome to your dashboard",
-        )
-        
-        # Call login, which hits the faked LOGIN_URL.
-        login_result = await omnisense.login("testuser", "testpass")
-        assert login_result is True
-        
-        # Call get_site_list to hit the faked SITE_LIST_URL and obtain the site dictionary.
-        # Fake site list GET request.
-        m.get(SITE_LIST_URL, status=200, body=site_html)
-        
-        # Construct expected sensor URL based on first site's number.
-        site_123456_url = f"{SENSOR_LIST_URL}?siteNbr=123456"
-        # Fake sensor list GET request with the sample sensor HTML.
-        m.get(site_123456_url, status=200, body=site_123456_sensors_html)
-        
-        site_654321_url = f"{SENSOR_LIST_URL}?siteNbr=654321"
-        # Fake sensor list GET request with the sample sensor HTML.
-        m.get(site_654321_url, status=200, body=site_654321_sensors_html)        
-                
-        sensor_result = await omnisense.get_sensor_data(sensor_ids=["2A000002", "2A008003", "2A008002", "2A001005"])
-        
-        # Define the expected sensor result (adjust as necessary based on your parsing logic).
-        expected_sensor_result = {
-          '2A000002': {'description': 'Basement', 'last_activity': '24-12-30 10:59:04', 'status': 'A', 'temperature': 29.2, 'relative_humidity': '30.4', 'absolute_humidity': '7.7', 'dew_point': '10.1', 'wood_pct': '6.9', 'battery_voltage': '3.4', 'sensor_type': 'S-11', 'sensor_id': '2A000002', 'site_name': 'MySite'}, 
-          '2A001005': {'description': 'Laundry Room', 'last_activity': '24-12-22 10:51:17', 'status': 'A', 'temperature': 14.4, 'relative_humidity': '63.6', 'absolute_humidity': '6.5', 'dew_point': '7.6', 'wood_pct': '13.2', 'battery_voltage': '3.2', 'sensor_type': 'S-11', 'sensor_id': '2A001005', 'site_name': 'FirstSite'}
-          }
-        assert sensor_result == expected_sensor_result
-        
-        # Close the session to clean up.
-        await omnisense.close()
-        
-@pytest.mark.offline        
+    result = await omnisense.get_sensor_data(
+        sensor_ids=["2A000002", "2A008003", "2A008002", "2A001005"]
+    )
+    assert result == _subset("2A000002", "2A001005")
+
+
+@pytest.mark.offline
 @pytest.mark.asyncio
-async def test_get_sensor_data_sensor_id_list_specific_site_and_sensor_id():
-    # Load sample HTML content for the site list and sensor list from local files.
-    site_file_path = os.path.join(os.path.dirname(__file__), "samples", "site_list.html")
-    site_123456_sensors_file_path = os.path.join(os.path.dirname(__file__), "samples", "sensor_123456.html")
-    site_654321_sensors_file_path = os.path.join(os.path.dirname(__file__), "samples", "sensor_654321.html")
-    
-    with open(site_file_path, "r", encoding="utf-8") as f:
-        site_html = f.read()
-    
-    with open(site_123456_sensors_file_path, "r", encoding="utf-8") as f:
-        site_123456_sensors_html = f.read()
-        
-    with open(site_654321_sensors_file_path, "r", encoding="utf-8") as f:
-        site_654321_sensors_html = f.read()        
-    
-    omnisense = Omnisense()
-    
-    set_cookie_value = "ASP.NET_SessionId=abc123; Path=/; HttpOnly"
-    redirect_location = "/site_select.asp"
+async def test_specific_site_and_sensor_id(
+    logged_in, all_sensors_html, register_sensors
+):
+    omnisense, m = logged_in
+    register_sensors(m, {"123456": all_sensors_html["123456"]})
 
-    # Use aioresponses context to fake all external HTTP calls.
-    with aioresponses() as m:
-        # Mock the POST to LOGIN_URL with Set-Cookie and Location headers
-        m.post(
-            LOGIN_URL,
-            status=302,
-            headers={
-                "Set-Cookie": set_cookie_value,
-                "Location": redirect_location,
-            },
-            body="",
-        )
-        # Mock the GET to the redirect location with the manual Cookie header
-        m.get(
-            f"{HOST_URL}{redirect_location}",
-            status=200,
-            body="Welcome to your dashboard",
-        )
-        
-        # Call login, which hits the faked LOGIN_URL.
-        login_result = await omnisense.login("testuser", "testpass")
-        assert login_result is True
-        
-        # Call get_site_list to hit the faked SITE_LIST_URL and obtain the site dictionary.
-        # Fake site list GET request.
-        m.get(SITE_LIST_URL, status=200, body=site_html)
-        
-        # Construct expected sensor URL based on first site's number.
-        site_123456_url = f"{SENSOR_LIST_URL}?siteNbr=123456"
-        # Fake sensor list GET request with the sample sensor HTML.
-        m.get(site_123456_url, status=200, body=site_123456_sensors_html)
-        
-        site_654321_url = f"{SENSOR_LIST_URL}?siteNbr=654321"
-        # Fake sensor list GET request with the sample sensor HTML.
-        m.get(site_654321_url, status=200, body=site_654321_sensors_html)        
-                
-        sensor_result = await omnisense.get_sensor_data("123456", "2A000002")
-        
-        # Define the expected sensor result (adjust as necessary based on your parsing logic).
-        expected_sensor_result = {
-          '2A000002': {'description': 'Basement', 'last_activity': '24-12-30 10:59:04', 'status': 'A', 'temperature': 29.2, 'relative_humidity': '30.4', 'absolute_humidity': '7.7', 'dew_point': '10.1', 'wood_pct': '6.9', 'battery_voltage': '3.4', 'sensor_type': 'S-11', 'sensor_id': '2A000002', 'site_name': 'MySite'}, 
-          }
-        assert sensor_result == expected_sensor_result
-        
-        # Close the session to clean up.
-        await omnisense.close()           
-        
-@pytest.mark.offline        
+    result = await omnisense.get_sensor_data("123456", "2A000002")
+    assert result == _subset("2A000002")
+
+
+@pytest.mark.offline
 @pytest.mark.asyncio
-async def test_get_sensor_data_all_unknown_sensor_ids():
-    # Load sample HTML content for the site list and sensor list from local files.
-    site_file_path = os.path.join(os.path.dirname(__file__), "samples", "site_list.html")
-    site_123456_sensors_file_path = os.path.join(os.path.dirname(__file__), "samples", "sensor_123456.html")
-    site_654321_sensors_file_path = os.path.join(os.path.dirname(__file__), "samples", "sensor_654321.html")
-    
-    with open(site_file_path, "r", encoding="utf-8") as f:
-        site_html = f.read()
-    
-    with open(site_123456_sensors_file_path, "r", encoding="utf-8") as f:
-        site_123456_sensors_html = f.read()
-        
-    with open(site_654321_sensors_file_path, "r", encoding="utf-8") as f:
-        site_654321_sensors_html = f.read()        
-    
-    omnisense = Omnisense()
-    
-    set_cookie_value = "ASP.NET_SessionId=abc123; Path=/; HttpOnly"
-    redirect_location = "/site_select.asp"
+async def test_all_unknown_sensor_ids_returns_empty(
+    logged_in, sample_site_html, all_sensors_html, register_sensors
+):
+    omnisense, m = logged_in
+    m.get(SITE_LIST_URL, status=200, body=sample_site_html)
+    register_sensors(m, all_sensors_html)
 
-    # Use aioresponses context to fake all external HTTP calls.
-    with aioresponses() as m:
-        # Mock the POST to LOGIN_URL with Set-Cookie and Location headers
-        m.post(
-            LOGIN_URL,
-            status=302,
-            headers={
-                "Set-Cookie": set_cookie_value,
-                "Location": redirect_location,
-            },
-            body="",
-        )
-        # Mock the GET to the redirect location with the manual Cookie header
-        m.get(
-            f"{HOST_URL}{redirect_location}",
-            status=200,
-            body="Welcome to your dashboard",
-        )
-        
-        # Call login, which hits the faked LOGIN_URL.
-        login_result = await omnisense.login("testuser", "testpass")
-        assert login_result is True
-        
-        # Call get_site_list to hit the faked SITE_LIST_URL and obtain the site dictionary.
-        # Fake site list GET request.
-        m.get(SITE_LIST_URL, status=200, body=site_html)
-        
-        # Construct expected sensor URL based on first site's number.
-        site_123456_url = f"{SENSOR_LIST_URL}?siteNbr=123456"
-        # Fake sensor list GET request with the sample sensor HTML.
-        m.get(site_123456_url, status=200, body=site_123456_sensors_html)
-                
-        sensor_result = await omnisense.get_sensor_data(sensor_ids="ABC0001")
-        
-        # Define the expected sensor result (adjust as necessary based on your parsing logic).
-        expected_sensor_result = {}
-        assert sensor_result == expected_sensor_result
-        
-        # Close the session to clean up.
-        await omnisense.close()            
+    result = await omnisense.get_sensor_data(
+        sensor_ids=["DEADBEEF", "CAFEBABE"]
+    )
+    assert result == {}

--- a/tests/sensor_select_test.py
+++ b/tests/sensor_select_test.py
@@ -1,311 +1,75 @@
-import os
+"""Tests for ``Omnisense.get_site_sensor_list`` (the projection helper)."""
+
 import pytest
-from aioresponses import aioresponses
-from pyomnisense.omnisense import Omnisense, LOGIN_URL, SITE_LIST_URL, SENSOR_LIST_URL, HOST_URL
+
+from pyomnisense.omnisense import SITE_LIST_URL
+
+
+# Canonical projection result for all sites - description / sensor_type /
+# site_name only.
+ALL_PROJECTED = {
+    "2A000001": {"description": "Dining Room",         "sensor_type": "S-11",  "site_name": "MySite"},
+    "2A000002": {"description": "Basement",            "sensor_type": "S-11",  "site_name": "MySite"},
+    "2A000003": {"description": "Gateway",             "sensor_type": "S-11",  "site_name": "MySite"},
+    "2A000004": {"description": "Kitchen",             "sensor_type": "S-11",  "site_name": "MySite"},
+    "2A000005": {"description": "Laundry Room",        "sensor_type": "S-11",  "site_name": "MySite"},
+    "6BC00000": {"description": "<description not set>", "sensor_type": "S-100", "site_name": "MySite"},
+    "2A001001": {"description": "Dining Room",         "sensor_type": "S-11",  "site_name": "FirstSite"},
+    "2A001002": {"description": "Basement",            "sensor_type": "S-11",  "site_name": "FirstSite"},
+    "2A001003": {"description": "Gateway",             "sensor_type": "S-11",  "site_name": "FirstSite"},
+    "2A001004": {"description": "Kitchen",             "sensor_type": "S-11",  "site_name": "FirstSite"},
+    "2A001005": {"description": "Laundry Room",        "sensor_type": "S-11",  "site_name": "FirstSite"},
+}
+
+SITE_123456_IDS = {sid for sid, info in ALL_PROJECTED.items() if info["site_name"] == "MySite"}
+
 
 @pytest.mark.offline
 @pytest.mark.asyncio
-async def test_get_sensor_list_no_args():
-    # Load sample HTML content for the site list and sensor list from local files.
-    site_file_path = os.path.join(os.path.dirname(__file__), "samples", "site_list.html")
-    site_123456_sensors_file_path = os.path.join(os.path.dirname(__file__), "samples", "sensor_123456.html")
-    site_654321_sensors_file_path = os.path.join(os.path.dirname(__file__), "samples", "sensor_654321.html")
-    
-    with open(site_file_path, "r", encoding="utf-8") as f:
-        site_html = f.read()
-    
-    with open(site_123456_sensors_file_path, "r", encoding="utf-8") as f:
-        site_123456_sensors_html = f.read()
-        
-    with open(site_654321_sensors_file_path, "r", encoding="utf-8") as f:
-        site_654321_sensors_html = f.read()        
-    
-    omnisense = Omnisense()
-    
-    set_cookie_value = "ASP.NET_SessionId=abc123; Path=/; HttpOnly"
-    redirect_location = "/site_select.asp"    
-    
-    # Use aioresponses context to fake all external HTTP calls.
-    with aioresponses() as m:
-        # Mock the POST to LOGIN_URL with Set-Cookie and Location headers
-        m.post(
-            LOGIN_URL,
-            status=302,
-            headers={
-                "Set-Cookie": set_cookie_value,
-                "Location": redirect_location,
-            },
-            body="",
-        )
-        # Mock the GET to the redirect location with the manual Cookie header
-        m.get(
-            f"{HOST_URL}{redirect_location}",
-            status=200,
-            body="Welcome to your dashboard",
-        )
-        
-        # Call login, which hits the faked LOGIN_URL.
-        login_result = await omnisense.login("testuser", "testpass")
-        assert login_result is True
-        
-        # Call get_site_list to hit the faked SITE_LIST_URL and obtain the site dictionary.
-        # Fake site list GET request.
-        m.get(SITE_LIST_URL, status=200, body=site_html)
-        
-        # Construct expected sensor URL based on first site's number.
-        site_123456_url = f"{SENSOR_LIST_URL}?siteNbr=123456"
-        # Fake sensor list GET request with the sample sensor HTML.
-        m.get(site_123456_url, status=200, body=site_123456_sensors_html)
-                
-        site_654321_url = f"{SENSOR_LIST_URL}?siteNbr=654321"
-        # Fake sensor list GET request with the sample sensor HTML.
-        m.get(site_654321_url, status=200, body=site_654321_sensors_html)
+async def test_no_args_returns_projection_for_all_sites(
+    logged_in, sample_site_html, all_sensors_html, register_sensors
+):
+    omnisense, m = logged_in
+    m.get(SITE_LIST_URL, status=200, body=sample_site_html)
+    register_sensors(m, all_sensors_html)
 
-        sensor_result = await omnisense.get_site_sensor_list()
-        
-        # Define the expected sensor result (adjust as necessary based on your parsing logic).
-        expected_sensor_result = {'2A000001': {'description': 'Dining Room', 'sensor_type': 'S-11', 'site_name': 'MySite'}, 
-                                  '2A000002': {'description': 'Basement', 'sensor_type': 'S-11', 'site_name': 'MySite'}, 
-                                  '2A000003': {'description': 'Gateway', 'sensor_type': 'S-11', 'site_name': 'MySite'}, 
-                                  '2A000004': {'description': 'Kitchen', 'sensor_type': 'S-11', 'site_name': 'MySite'}, 
-                                  '2A000005': {'description': 'Laundry Room', 'sensor_type': 'S-11', 'site_name': 'MySite'}, 
-                                  '6BC00000': {'description': '<description not set>', 'sensor_type': 'S-100', 'site_name': 'MySite'},
-                                  '2A001001': {'description': 'Dining Room', 'sensor_type': 'S-11', 'site_name': 'FirstSite'}, 
-                                  '2A001002': {'description': 'Basement', 'sensor_type': 'S-11', 'site_name': 'FirstSite'}, 
-                                  '2A001003': {'description': 'Gateway', 'sensor_type': 'S-11', 'site_name': 'FirstSite'}, 
-                                  '2A001004': {'description': 'Kitchen', 'sensor_type': 'S-11', 'site_name': 'FirstSite'}, 
-                                  '2A001005': {'description': 'Laundry Room', 'sensor_type': 'S-11', 'site_name': 'FirstSite'}
-                                }
-        assert sensor_result == expected_sensor_result
-        
-        # Close the session to clean up.
-        await omnisense.close()
+    assert await omnisense.get_site_sensor_list() == ALL_PROJECTED
+
 
 @pytest.mark.offline
 @pytest.mark.asyncio
-async def test_get_sensor_list_pass_site_id_dict():
-    # Load sample HTML content for the site list and sensor list from local files.
-    site_file_path = os.path.join(os.path.dirname(__file__), "samples", "site_list.html")
-    site_123456_sensors_file_path = os.path.join(os.path.dirname(__file__), "samples", "sensor_123456.html")
-    site_654321_sensors_file_path = os.path.join(os.path.dirname(__file__), "samples", "sensor_654321.html")
-    
-    with open(site_file_path, "r", encoding="utf-8") as f:
-        site_html = f.read()
-    
-    with open(site_123456_sensors_file_path, "r", encoding="utf-8") as f:
-        site_123456_sensors_html = f.read()
-        
-    with open(site_654321_sensors_file_path, "r", encoding="utf-8") as f:
-        site_654321_sensors_html = f.read()        
-    
-    omnisense = Omnisense()
-    
-    set_cookie_value = "ASP.NET_SessionId=abc123; Path=/; HttpOnly"
-    redirect_location = "/site_select.asp"    
-    
-    # Use aioresponses context to fake all external HTTP calls.
-    with aioresponses() as m:
-        # Mock the POST to LOGIN_URL with Set-Cookie and Location headers
-        m.post(
-            LOGIN_URL,
-            status=302,
-            headers={
-                "Set-Cookie": set_cookie_value,
-                "Location": redirect_location,
-            },
-            body="",
-        )
-        # Mock the GET to the redirect location with the manual Cookie header
-        m.get(
-            f"{HOST_URL}{redirect_location}",
-            status=200,
-            body="Welcome to your dashboard",
-        )
-        
-        # Call login, which hits the faked LOGIN_URL.
-        login_result = await omnisense.login("testuser", "testpass")
-        assert login_result is True
-        
-        # Call get_site_list to hit the faked SITE_LIST_URL and obtain the site dictionary.
-        # Fake site list GET request.
-        m.get(SITE_LIST_URL, status=200, body=site_html)
-        
-        # Construct expected sensor URL based on first site's number.
-        site_123456_url = f"{SENSOR_LIST_URL}?siteNbr=123456"
-        # Fake sensor list GET request with the sample sensor HTML.
-        m.get(site_123456_url, status=200, body=site_123456_sensors_html)
-                
-        site_654321_url = f"{SENSOR_LIST_URL}?siteNbr=654321"
-        # Fake sensor list GET request with the sample sensor HTML.
-        m.get(site_654321_url, status=200, body=site_654321_sensors_html)
-        
-        site_ids = await omnisense.get_site_list()
+async def test_pass_site_id_dict(
+    logged_in, sample_site_html, all_sensors_html, register_sensors
+):
+    omnisense, m = logged_in
+    m.get(SITE_LIST_URL, status=200, body=sample_site_html)
+    register_sensors(m, all_sensors_html)
 
-        sensor_result = await omnisense.get_site_sensor_list(site_ids)
-        
-        # Define the expected sensor result (adjust as necessary based on your parsing logic).
-        expected_sensor_result = {'2A000001': {'description': 'Dining Room', 'sensor_type': 'S-11', 'site_name': 'MySite'}, 
-                                  '2A000002': {'description': 'Basement', 'sensor_type': 'S-11', 'site_name': 'MySite'}, 
-                                  '2A000003': {'description': 'Gateway', 'sensor_type': 'S-11', 'site_name': 'MySite'}, 
-                                  '2A000004': {'description': 'Kitchen', 'sensor_type': 'S-11', 'site_name': 'MySite'}, 
-                                  '2A000005': {'description': 'Laundry Room', 'sensor_type': 'S-11', 'site_name': 'MySite'}, 
-                                  '6BC00000': {'description': '<description not set>', 'sensor_type': 'S-100', 'site_name': 'MySite'},
-                                  '2A001001': {'description': 'Dining Room', 'sensor_type': 'S-11', 'site_name': 'FirstSite'}, 
-                                  '2A001002': {'description': 'Basement', 'sensor_type': 'S-11', 'site_name': 'FirstSite'}, 
-                                  '2A001003': {'description': 'Gateway', 'sensor_type': 'S-11', 'site_name': 'FirstSite'}, 
-                                  '2A001004': {'description': 'Kitchen', 'sensor_type': 'S-11', 'site_name': 'FirstSite'}, 
-                                  '2A001005': {'description': 'Laundry Room', 'sensor_type': 'S-11', 'site_name': 'FirstSite'}
-                                }
-        assert sensor_result == expected_sensor_result
-        
-        # Close the session to clean up.
-        await omnisense.close()
-        
-@pytest.mark.offline        
-@pytest.mark.asyncio
-async def test_get_sensor_list_pass_site_id_list():
-    # Load sample HTML content for the site list and sensor list from local files.
-    site_file_path = os.path.join(os.path.dirname(__file__), "samples", "site_list.html")
-    site_123456_sensors_file_path = os.path.join(os.path.dirname(__file__), "samples", "sensor_123456.html")
-    site_654321_sensors_file_path = os.path.join(os.path.dirname(__file__), "samples", "sensor_654321.html")
-    
-    with open(site_file_path, "r", encoding="utf-8") as f:
-        site_html = f.read()
-    
-    with open(site_123456_sensors_file_path, "r", encoding="utf-8") as f:
-        site_123456_sensors_html = f.read()
-        
-    with open(site_654321_sensors_file_path, "r", encoding="utf-8") as f:
-        site_654321_sensors_html = f.read()        
-    
-    omnisense = Omnisense()
-    
-    set_cookie_value = "ASP.NET_SessionId=abc123; Path=/; HttpOnly"
-    redirect_location = "/site_select.asp"    
-    
-    # Use aioresponses context to fake all external HTTP calls.
-    with aioresponses() as m:
-        # Mock the POST to LOGIN_URL with Set-Cookie and Location headers
-        m.post(
-            LOGIN_URL,
-            status=302,
-            headers={
-                "Set-Cookie": set_cookie_value,
-                "Location": redirect_location,
-            },
-            body="",
-        )
-        # Mock the GET to the redirect location with the manual Cookie header
-        m.get(
-            f"{HOST_URL}{redirect_location}",
-            status=200,
-            body="Welcome to your dashboard",
-        )
-        
-        # Call login, which hits the faked LOGIN_URL.
-        login_result = await omnisense.login("testuser", "testpass")
-        assert login_result is True
-        
-        # Call get_site_list to hit the faked SITE_LIST_URL and obtain the site dictionary.
-        # Fake site list GET request.
-        m.get(SITE_LIST_URL, status=200, body=site_html)
-        
-        # Construct expected sensor URL based on first site's number.
-        site_123456_url = f"{SENSOR_LIST_URL}?siteNbr=123456"
-        # Fake sensor list GET request with the sample sensor HTML.
-        m.get(site_123456_url, status=200, body=site_123456_sensors_html)
-                
-        site_654321_url = f"{SENSOR_LIST_URL}?siteNbr=654321"
-        # Fake sensor list GET request with the sample sensor HTML.
-        m.get(site_654321_url, status=200, body=site_654321_sensors_html)
-        
-        site_ids = await omnisense.get_site_list()
+    site_ids = await omnisense.get_site_list()
+    assert await omnisense.get_site_sensor_list(site_ids) == ALL_PROJECTED
 
-        sensor_result = await omnisense.get_site_sensor_list(list(site_ids.keys()))
-        
-        # Define the expected sensor result (adjust as necessary based on your parsing logic).
-        expected_sensor_result = {'2A000001': {'description': 'Dining Room', 'sensor_type': 'S-11', 'site_name': 'MySite'}, 
-                                  '2A000002': {'description': 'Basement', 'sensor_type': 'S-11', 'site_name': 'MySite'}, 
-                                  '2A000003': {'description': 'Gateway', 'sensor_type': 'S-11', 'site_name': 'MySite'}, 
-                                  '2A000004': {'description': 'Kitchen', 'sensor_type': 'S-11', 'site_name': 'MySite'}, 
-                                  '2A000005': {'description': 'Laundry Room', 'sensor_type': 'S-11', 'site_name': 'MySite'}, 
-                                  '6BC00000': {'description': '<description not set>', 'sensor_type': 'S-100', 'site_name': 'MySite'},
-                                  '2A001001': {'description': 'Dining Room', 'sensor_type': 'S-11', 'site_name': 'FirstSite'}, 
-                                  '2A001002': {'description': 'Basement', 'sensor_type': 'S-11', 'site_name': 'FirstSite'}, 
-                                  '2A001003': {'description': 'Gateway', 'sensor_type': 'S-11', 'site_name': 'FirstSite'}, 
-                                  '2A001004': {'description': 'Kitchen', 'sensor_type': 'S-11', 'site_name': 'FirstSite'}, 
-                                  '2A001005': {'description': 'Laundry Room', 'sensor_type': 'S-11', 'site_name': 'FirstSite'}
-                                }
-        assert sensor_result == expected_sensor_result
-        
-        # Close the session to clean up.
-        await omnisense.close()
-        
-@pytest.mark.offline        
+
+@pytest.mark.offline
 @pytest.mark.asyncio
-async def test_get_sensor_list_pass_single_site_id_string():
-    # Load sample HTML content for the site list and sensor list from local files.
-    site_file_path = os.path.join(os.path.dirname(__file__), "samples", "site_list.html")
-    site_123456_sensors_file_path = os.path.join(os.path.dirname(__file__), "samples", "sensor_123456.html")
-    site_654321_sensors_file_path = os.path.join(os.path.dirname(__file__), "samples", "sensor_654321.html")
-    
-    with open(site_file_path, "r", encoding="utf-8") as f:
-        site_html = f.read()
-    
-    with open(site_123456_sensors_file_path, "r", encoding="utf-8") as f:
-        site_123456_sensors_html = f.read()
-        
-    with open(site_654321_sensors_file_path, "r", encoding="utf-8") as f:
-        site_654321_sensors_html = f.read()        
-    
-    omnisense = Omnisense()
-    
-    set_cookie_value = "ASP.NET_SessionId=abc123; Path=/; HttpOnly"
-    redirect_location = "/site_select.asp"    
-    
-    # Use aioresponses context to fake all external HTTP calls.
-    with aioresponses() as m:
-        # Mock the POST to LOGIN_URL with Set-Cookie and Location headers
-        m.post(
-            LOGIN_URL,
-            status=302,
-            headers={
-                "Set-Cookie": set_cookie_value,
-                "Location": redirect_location,
-            },
-            body="",
-        )
-        # Mock the GET to the redirect location with the manual Cookie header
-        m.get(
-            f"{HOST_URL}{redirect_location}",
-            status=200,
-            body="Welcome to your dashboard",
-        )
-        
-        # Call login, which hits the faked LOGIN_URL.
-        login_result = await omnisense.login("testuser", "testpass")
-        assert login_result is True
-        
-        # Call get_site_list to hit the faked SITE_LIST_URL and obtain the site dictionary.
-        # Fake site list GET request.
-        m.get(SITE_LIST_URL, status=200, body=site_html)
-        
-        # Construct expected sensor URL based on first site's number.
-        site_123456_url = f"{SENSOR_LIST_URL}?siteNbr=123456"
-        # Fake sensor list GET request with the sample sensor HTML.
-        m.get(site_123456_url, status=200, body=site_123456_sensors_html)
-                
-        sensor_result = await omnisense.get_site_sensor_list("123456")
-        
-        # Define the expected sensor result (adjust as necessary based on your parsing logic).
-        expected_sensor_result = {'2A000001': {'description': 'Dining Room', 'sensor_type': 'S-11', 'site_name': 'MySite'}, 
-                                  '2A000002': {'description': 'Basement', 'sensor_type': 'S-11', 'site_name': 'MySite'}, 
-                                  '2A000003': {'description': 'Gateway', 'sensor_type': 'S-11', 'site_name': 'MySite'}, 
-                                  '2A000004': {'description': 'Kitchen', 'sensor_type': 'S-11', 'site_name': 'MySite'}, 
-                                  '2A000005': {'description': 'Laundry Room', 'sensor_type': 'S-11', 'site_name': 'MySite'}, 
-                                  '6BC00000': {'description': '<description not set>', 'sensor_type': 'S-100', 'site_name': 'MySite'},
-                                }
-        assert sensor_result == expected_sensor_result
-        
-        # Close the session to clean up.
-        await omnisense.close()         
+async def test_pass_site_id_list(
+    logged_in, sample_site_html, all_sensors_html, register_sensors
+):
+    omnisense, m = logged_in
+    m.get(SITE_LIST_URL, status=200, body=sample_site_html)
+    register_sensors(m, all_sensors_html)
+
+    site_ids = await omnisense.get_site_list()
+    result = await omnisense.get_site_sensor_list(list(site_ids.keys()))
+    assert result == ALL_PROJECTED
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_pass_single_site_id_string(
+    logged_in, all_sensors_html, register_sensors
+):
+    omnisense, m = logged_in
+    register_sensors(m, {"123456": all_sensors_html["123456"]})
+
+    result = await omnisense.get_site_sensor_list("123456")
+    assert result == {sid: ALL_PROJECTED[sid] for sid in SITE_123456_IDS}

--- a/tests/session_reuse_test.py
+++ b/tests/session_reuse_test.py
@@ -10,117 +10,73 @@ configured with ``quote_cookie=False``:
   once and retry without the caller having to know.
 """
 
-import os
 import pytest
 from aioresponses import aioresponses
 
 from pyomnisense.omnisense import (
+    HOST_URL,
+    LOGIN_URL,
+    SENSOR_LIST_URL,
+    SITE_LIST_URL,
     Omnisense,
     OmnisenseAuthError,
-    LOGIN_URL,
-    SITE_LIST_URL,
-    SENSOR_LIST_URL,
-    HOST_URL,
 )
 
 
-SAMPLES_DIR = os.path.join(os.path.dirname(__file__), "samples")
-
-
-def _load_sample(name: str) -> str:
-    with open(os.path.join(SAMPLES_DIR, name), "r", encoding="utf-8") as f:
-        return f.read()
-
-
-def _mock_successful_login(m: aioresponses, set_cookie: str = "ASP.NET_SessionId=abc123; Path=/; HttpOnly") -> None:
-    """Register a POST /user_login.asp + GET /site_select.asp pair that
-    together represent one successful login round-trip."""
-    m.post(
-        LOGIN_URL,
-        status=302,
-        headers={"Set-Cookie": set_cookie, "Location": "/site_select.asp"},
-        body="",
-    )
-    m.get(
-        f"{HOST_URL}/site_select.asp",
-        status=200,
-        body="Welcome to your dashboard",
-    )
-
-
 @pytest.mark.offline
 @pytest.mark.asyncio
-async def test_session_is_reused_across_calls():
+async def test_session_is_reused_across_calls(
+    logged_in, sample_site_html, sample_sensors_123456
+):
     """Two data calls after one login must not trigger a second login.
 
-    If the implementation accidentally re-logs in, the second POST to
-    LOGIN_URL would have no registered response and aioresponses would
-    raise, failing the test.
+    The ``logged_in`` fixture registers exactly ONE login round-trip; if
+    the client tries to log in again, the second POST to LOGIN_URL has
+    no mock and aioresponses will raise.
     """
-    site_html = _load_sample("site_list.html")
-    sensors_html = _load_sample("sensor_123456.html")
+    omnisense, m = logged_in
+    m.get(SITE_LIST_URL, status=200, body=sample_site_html)
+    m.get(f"{SENSOR_LIST_URL}?siteNbr=123456", status=200, body=sample_sensors_123456)
 
-    with aioresponses() as m:
-        _mock_successful_login(m)
-        # One registration each: if the client tries to fetch them twice
-        # (or, worse, re-login between them), aioresponses will fail.
-        m.get(SITE_LIST_URL, status=200, body=site_html)
-        m.get(f"{SENSOR_LIST_URL}?siteNbr=123456", status=200, body=sensors_html)
+    sites = await omnisense.get_site_list()
+    assert sites == {"123456": "MySite", "654321": "FirstSite"}
 
-        omnisense = Omnisense()
-        assert await omnisense.login("user", "pass") is True
-
-        sites = await omnisense.get_site_list()
-        assert sites == {"123456": "MySite", "654321": "FirstSite"}
-
-        sensors = await omnisense.get_sensor_data("123456")
-        assert "2A000001" in sensors
-        assert sensors["2A000001"]["site_name"] == "MySite"
-
-        await omnisense.close()
+    sensors = await omnisense.get_sensor_data("123456")
+    assert "2A000001" in sensors
+    assert sensors["2A000001"]["site_name"] == "MySite"
 
 
 @pytest.mark.offline
 @pytest.mark.asyncio
-async def test_relogin_on_session_expiry():
+async def test_relogin_on_session_expiry(
+    logged_in, register_login, sample_site_html
+):
     """If a data fetch lands on the login page, the client must re-login
     once and retry transparently."""
-    site_html = _load_sample("site_list.html")
+    omnisense, m = logged_in
 
-    with aioresponses() as m:
-        _mock_successful_login(m)
+    # First GET of the site list "expires": server 302s to the login
+    # page and aiohttp follows the redirect (default behaviour).
+    m.get(SITE_LIST_URL, status=302, headers={"Location": "/user_login.asp"})
+    m.get(
+        f"{HOST_URL}/user_login.asp",
+        status=200,
+        body="<html><form>login form here</form></html>",
+    )
 
-        # First GET of the site list "expires": server redirects to the
-        # login page and aiohttp follows the redirect (default behaviour).
-        m.get(
-            SITE_LIST_URL,
-            status=302,
-            headers={"Location": "/user_login.asp"},
-        )
-        m.get(
-            f"{HOST_URL}/user_login.asp",
-            status=200,
-            body="<html><form>login form here</form></html>",
-        )
+    # Transparent re-login: another POST + dashboard GET pair.
+    register_login(m, set_cookie="ASP.NET_SessionId=def456; Path=/; HttpOnly")
 
-        # Transparent re-login: another POST + dashboard GET pair.
-        _mock_successful_login(m, set_cookie="ASP.NET_SessionId=def456; Path=/; HttpOnly")
+    # Retry of the original data call now succeeds.
+    m.get(SITE_LIST_URL, status=200, body=sample_site_html)
 
-        # Retry of the original data call now succeeds.
-        m.get(SITE_LIST_URL, status=200, body=site_html)
-
-        omnisense = Omnisense()
-        assert await omnisense.login("user", "pass") is True
-
-        sites = await omnisense.get_site_list()
-        assert sites == {"123456": "MySite", "654321": "FirstSite"}
-
-        await omnisense.close()
+    sites = await omnisense.get_site_list()
+    assert sites == {"123456": "MySite", "654321": "FirstSite"}
 
 
 @pytest.mark.offline
 @pytest.mark.asyncio
-async def test_login_replaces_credentials_atomically():
+async def test_login_rejects_partial_credentials():
     """Passing only one of username/password must be a hard error, not
     a silent partial update that re-uses cached credentials of the
     *other* user."""
@@ -134,11 +90,11 @@ async def test_login_replaces_credentials_atomically():
 
 @pytest.mark.offline
 @pytest.mark.asyncio
-async def test_relogin_closes_old_session():
+async def test_relogin_closes_old_session(register_login):
     """Calling login() twice must not leak the first ClientSession."""
     with aioresponses() as m:
-        _mock_successful_login(m)
-        _mock_successful_login(m, set_cookie="ASP.NET_SessionId=def456; Path=/; HttpOnly")
+        register_login(m)
+        register_login(m, set_cookie="ASP.NET_SessionId=def456; Path=/; HttpOnly")
 
         omnisense = Omnisense()
         assert await omnisense.login("user", "pass") is True
@@ -156,11 +112,10 @@ async def test_relogin_closes_old_session():
 
 @pytest.mark.offline
 @pytest.mark.asyncio
-async def test_context_manager_closes_session():
-    """``async with Omnisense()`` should close the session on exit, even
-    when the block raises."""
+async def test_context_manager_closes_session(register_login):
+    """``async with Omnisense()`` should close the session on exit."""
     with aioresponses() as m:
-        _mock_successful_login(m)
+        register_login(m)
 
         async with Omnisense() as omnisense:
             assert await omnisense.login("user", "pass") is True

--- a/tests/site_select_test.py
+++ b/tests/site_select_test.py
@@ -1,52 +1,17 @@
-import os
+"""Tests for ``Omnisense.get_site_list``."""
+
 import pytest
-from aioresponses import aioresponses
-from pyomnisense.omnisense import Omnisense, LOGIN_URL, SITE_LIST_URL, HOST_URL
+
+from pyomnisense.omnisense import SITE_LIST_URL
+
 
 @pytest.mark.offline
 @pytest.mark.asyncio
-async def test_get_site_list():
-    site_file_path = os.path.join(os.path.dirname(__file__), "samples", "site_list.html")
-    
-    with open(site_file_path, "r", encoding="utf-8") as f:
-        site_html = f.read()
-    
-    omnisense = Omnisense()
-    
-    set_cookie_value = "ASP.NET_SessionId=abc123; Path=/; HttpOnly"
-    redirect_location = "/site_select.asp"    
-    
-    # Use aioresponses context to fake all external HTTP calls.
-    with aioresponses() as m:
-        # Mock the POST to LOGIN_URL with Set-Cookie and Location headers
-        m.post(
-            LOGIN_URL,
-            status=302,
-            headers={
-                "Set-Cookie": set_cookie_value,
-                "Location": redirect_location,
-            },
-            body="",
-        )
-        # Mock the GET to the redirect location with the manual Cookie header
-        m.get(
-            f"{HOST_URL}{redirect_location}",
-            status=200,
-            body="Welcome to your dashboard",
-        )
-        # Fake site list GET request response with the sample HTML content
-        m.get(SITE_LIST_URL, status=200, body=site_html)
-        
-        # Call login, which will hit the faked LOGIN_URL endpoint
-        login_result = await omnisense.login("testuser", "testpass")
-        assert login_result is True
+async def test_get_site_list_parses_sample_html(logged_in, sample_site_html):
+    omnisense, m = logged_in
+    m.get(SITE_LIST_URL, status=200, body=sample_site_html)
 
-        # Now call get_site_list which will hit the faked SITE_LIST_URL endpoint
-        result = await omnisense.get_site_list()
-        
-        # Close the session to clean up
-        await omnisense.close()
-        
-        # Assert that the result matches the expected dict
-        expected_result = {'123456': 'MySite', '654321': 'FirstSite'}
-        assert result == expected_result
+    assert await omnisense.get_site_list() == {
+        "123456": "MySite",
+        "654321": "FirstSite",
+    }


### PR DESCRIPTION
Follow-up to #5 and #6, working the remaining test-suite items from #4.

### conftest.py (new)

Shared pytest fixtures that lift the repeated setup boilerplate out of every test file:

- `sample_site_html` / `sample_sensors_123456` / `sample_sensors_654321` — load the sample HTML files once.
- `all_sensors_html` — dict keyed by site_id.
- `register_login(m)` — registers POST /user_login.asp + dashboard GET pair on an `aioresponses` mock.
- `register_sensors(m, html_by_site_id)` — registers per-site sensor-list endpoints.
- `logged_in` — yields `(omnisense, m)` with login already performed.

### Rewrites against the fixtures (#19)

| File | Before | After |
|---|---|---|
| `sensor_data_test.py` | 706 lines | 175 lines |
| `sensor_select_test.py` | 367 lines | ~70 lines |
| `site_select_test.py` | 51 lines | 18 lines |
| `login_test.py` | 94 lines | 68 lines |
| `session_reuse_test.py` | 172 lines | 120 lines |
| **Total** | **1279** | **450** |

Same 25 offline test cases, same coverage.

### live_test.py (#20 + #21)

- Drop the hardcoded `{'119345': 'Home', '143554': 'BDL'}` and `len(sensor_data) == 14` assertions tied to a specific account. Now any collaborator with valid Omnisense credentials can run this test against their own account and pass.
- Fix the nested `for key in data.keys(): for key in ...` block that shadowed the outer `key` and re-asserted membership N times per sensor. Replaced with a single `assert set(reading.keys()) == EXPECTED_SENSOR_KEYS` per sensor.
- Use the new `async with Omnisense() as o` form so the session is closed even if an assertion fails.

### Verification

`pytest -m offline` → **25 passed**.

Refs #4.