### PR TITLE
CI/packaging: matrix tests, OIDC publish, tag/version guard

### DIFF
--- a/.github/workflows/live_tests.yml
+++ b/.github/workflows/live_tests.yml
@@ -3,19 +3,19 @@ name: Live Test
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 0 * * *'  # Runs daily at midnight
+    - cron: '0 0 * * *'  # daily at midnight UTC
 
 jobs:
   live-test:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
-          python-version: '3.x'
+          python-version: '3.12'
 
       - name: Install dependencies
         run: |
@@ -26,5 +26,4 @@ jobs:
         env:
           OMNISENSE_USERNAME: ${{ secrets.OMNISENSE_USERNAME }}
           OMNISENSE_PASSWORD: ${{ secrets.OMNISENSE_PASSWORD }}
-        run: |
-          pytest -s -m live
+        run: pytest -s -m live

--- a/.github/workflows/offline_tests.yml
+++ b/.github/workflows/offline_tests.yml
@@ -2,26 +2,30 @@ name: Run Tests
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.10', '3.11', '3.12', '3.13']
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
         with:
-          python-version: '3.x'
+          python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install -e .[tests]
 
-      - name: Run tests
-        run: pytest -s -m offline
+      - name: Run offline tests
+        run: pytest -m offline -v

--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -3,33 +3,65 @@ name: Publish to PyPI
 on:
   push:
     tags:
-      - 'v*'  # Triggers when you push a tag starting with "v", e.g., v1.0.0
+      - 'v*'  # any tag starting with "v", e.g. v0.2.0
 
 jobs:
-  build-and-publish:
+  test:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.10', '3.11', '3.12', '3.13']
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[tests]
+      - name: Run offline tests
+        run: pytest -m offline -v
 
+  verify-version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Verify tag matches pyproject.toml version
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          PYPROJECT_VERSION=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          echo "tag=${TAG_VERSION} pyproject=${PYPROJECT_VERSION}"
+          if [ "$TAG_VERSION" != "$PYPROJECT_VERSION" ]; then
+            echo "::error::Tag version (${TAG_VERSION}) does not match pyproject.toml version (${PYPROJECT_VERSION})"
+            exit 1
+          fi
+
+  build-and-publish:
+    needs: [test, verify-version]
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # required for PyPI Trusted Publishing (OIDC)
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
-          python-version: '3.x'
+          python-version: '3.12'
 
       - name: Upgrade pip and install build tools
         run: |
           python -m pip install --upgrade pip
-          pip install build twine
+          pip install build
 
       - name: Build the package
-        run: |
-          python -m build --sdist --wheel
+        run: python -m build --sdist --wheel
 
       - name: Publish package to PyPI
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-        run: |
-          python -m twine upload dist/*
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Last batch of items from #4, all CI / packaging.

### `offline_tests.yml` (#23 + #24)
- Run on a Python matrix of `[3.10, 3.11, 3.12, 3.13]` instead of the non-deterministic `'3.x'` floating tag, so we actually exercise the supported floor.
- `fail-fast: false` so all matrix cells report even if one fails.
- Bump `actions/checkout@v3` → `@v4`, `actions/setup-python@v4` → `@v5`.

### `live_tests.yml` (#24)
- Pin Python to 3.12 (no point in fan-out for a real-API smoke).
- Bump action majors as above.

### `publish_to_pypi.yml` (#25 + #26 + #27)
- Switch to **PyPI Trusted Publisher / OIDC**: drop the long-lived `PYPI_API_TOKEN` secret, replace the twine upload step with `pypa/gh-action-pypi-publish@release/v1` and grant the job `id-token: write`.
- Add a `test` job (same matrix as `offline_tests.yml`) and make `build-and-publish` `needs: [test, verify-version]` so a broken build can never accidentally publish.
- Add a `verify-version` job that parses `pyproject.toml` with `tomllib` and asserts that the pushed tag (minus the leading `v`) matches the declared version. Prevents the classic "tag says v0.3.0, pyproject still says 0.2.0" mis-publish.

### Required one-time PyPI setup

Enabling Trusted Publishing also requires a one-time configuration on PyPI: <https://pypi.org/manage/account/publishing/>. Add a pending or active publisher with:

- **owner**: `sslivins`
- **repo**: `pyomnisense`
- **workflow**: `publish_to_pypi.yml`
- **environment**: *(leave blank)*

Once that's done the long-lived `PYPI_API_TOKEN` secret can be revoked.

Refs #4.