### PR TITLE
pyomnisense 0.3.0: typed numerics, datetime last_activity, propagate auth errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyomnisense"          
-version = "0.2.0"             
+version = "0.3.0"             
 description = "Python library for accessing Omnisense sensor data from omnisense.com"
 readme = "README.md"          
 license = { text = "MIT" }    

--- a/src/pyomnisense/__init__.py
+++ b/src/pyomnisense/__init__.py
@@ -11,4 +11,4 @@ __all__ = [
     "OmnisenseError",
     "SensorReading",
 ]
-__version__ = "0.2.0"
+__version__ = "0.3.0"

--- a/src/pyomnisense/omnisense.py
+++ b/src/pyomnisense/omnisense.py
@@ -1,5 +1,6 @@
 import logging
 import re
+from datetime import datetime, timezone
 from typing import Dict, List, Optional, TypedDict, Union
 
 import aiohttp
@@ -29,20 +30,58 @@ class OmnisenseAuthError(OmnisenseError):
 
 
 class SensorReading(TypedDict):
-    """Shape of a single sensor's reading as returned by ``get_sensor_data``."""
+    """Shape of a single sensor's reading as returned by ``get_sensor_data``.
+
+    Numeric fields are parsed to ``float`` (``None`` if the source page
+    showed a non-numeric placeholder), and ``last_activity`` is a
+    timezone-aware ``datetime`` in UTC (``None`` if it could not be
+    parsed). omnisense.com emits all timestamps in UTC.
+    """
 
     description: str
-    last_activity: str
+    last_activity: Optional[datetime]
     status: str
     temperature: Optional[float]
-    relative_humidity: str
-    absolute_humidity: str
-    dew_point: str
-    wood_pct: str
-    battery_voltage: str
+    relative_humidity: Optional[float]
+    absolute_humidity: Optional[float]
+    dew_point: Optional[float]
+    wood_pct: Optional[float]
+    battery_voltage: Optional[float]
     sensor_type: Optional[str]
     sensor_id: str
     site_name: Optional[str]
+
+
+def _parse_float(value: str) -> Optional[float]:
+    """Best-effort ``float`` parse for sensor-reading cells.
+
+    Returns ``None`` instead of raising when the cell holds a non-numeric
+    placeholder (e.g. an empty string for a sensor that hasn't reported
+    that field yet).
+    """
+    if value is None:
+        return None
+    try:
+        return float(value.strip())
+    except (ValueError, AttributeError):
+        return None
+
+
+def _parse_timestamp(value: str) -> Optional[datetime]:
+    """Parse omnisense.com's naive ``YY-MM-DD HH:MM:SS`` timestamps.
+
+    Returns a timezone-aware ``datetime`` in UTC, or ``None`` if the
+    cell could not be parsed. omnisense.com emits server-local times
+    in UTC, so we label the naive parse result as UTC and let
+    downstream consumers convert to local for display.
+    """
+    if value is None:
+        return None
+    try:
+        naive = datetime.strptime(value.strip(), "%y-%m-%d %H:%M:%S")
+    except (ValueError, AttributeError):
+        return None
+    return naive.replace(tzinfo=timezone.utc)
 
 
 class Omnisense:
@@ -205,11 +244,24 @@ class Omnisense:
     async def get_site_list(self) -> dict:
         """Fetch the available sites.
 
+        If no session has been established yet, this implicitly logs in
+        using credentials previously supplied via :meth:`login`. If
+        no credentials are cached, ``OmnisenseAuthError`` is raised.
+
         Returns:
-            dict: ``{site_id: site_name}``. Returns an empty dict on error.
+            dict: ``{site_id: site_name}``. Returns an empty dict on
+            scrape / transport errors.
+
+        Raises:
+            OmnisenseAuthError: if the session is unrecoverable
+                (e.g. cached credentials no longer work).
         """
         try:
             text = await self._fetch_html(SITE_LIST_URL)
+        except OmnisenseAuthError:
+            # Unrecoverable auth failure -- propagate so callers can
+            # distinguish "session is dead" from "this scrape failed".
+            raise
         except Exception as err:
             _LOGGER.error("Error fetching site list: %s", err)
             return {}
@@ -233,22 +285,20 @@ class Omnisense:
             site_ids: ``{site_id: site_name}`` dict, list of site_id strings,
                 or a single site_id string. If omitted, all sites are
                 queried.
+
+        Raises:
+            OmnisenseAuthError: if the session has expired and re-login
+                fails (propagated from :meth:`get_sensor_data`).
         """
-        try:
-            sensor_data = await self.get_sensor_data(site_ids)
-            if not sensor_data:
-                return {}
-            return {
-                sid: {
-                    "description": info["description"],
-                    "sensor_type": info["sensor_type"],
-                    "site_name": info["site_name"],
-                }
-                for sid, info in sensor_data.items()
+        sensor_data = await self.get_sensor_data(site_ids)
+        return {
+            sid: {
+                "description": info["description"],
+                "sensor_type": info["sensor_type"],
+                "site_name": info["site_name"],
             }
-        except Exception as e:
-            _LOGGER.error("Error fetching sensors: %s", e)
-            return {}
+            for sid, info in sensor_data.items()
+        }
 
     async def get_sensor_data(
         self,
@@ -265,11 +315,17 @@ class Omnisense:
                 omitted, all sensors are returned.
 
         Returns:
-            dict keyed by sensor_id, where each value contains
-            ``description``, ``last_activity``, ``status``, ``temperature``,
+            dict keyed by sensor_id. Numeric fields (``temperature``,
             ``relative_humidity``, ``absolute_humidity``, ``dew_point``,
-            ``wood_pct``, ``battery_voltage``, ``sensor_type``,
-            ``sensor_id`` and ``site_name``.
+            ``wood_pct``, ``battery_voltage``) are parsed to ``float``
+            (``None`` on parse failure). ``last_activity`` is a
+            timezone-aware ``datetime`` in UTC (``None`` on parse
+            failure). See :class:`SensorReading` for the full shape.
+
+        Raises:
+            OmnisenseAuthError: if the session has expired and re-login
+                fails. Per-site scrape / transport failures are logged
+                and skipped (other sites still return their data).
         """
         if not site_ids:
             site_ids = await self.get_site_list()
@@ -296,6 +352,11 @@ class Omnisense:
 
             try:
                 text = await self._fetch_html(sensor_page_url)
+            except OmnisenseAuthError:
+                # Unrecoverable auth failure -- propagate so callers can
+                # distinguish "session is dead" from "this one site was
+                # transiently unreachable".
+                raise
             except Exception:
                 _LOGGER.exception(
                     "Error fetching sensor data for site id '%s'.", site_id
@@ -331,10 +392,6 @@ class Omnisense:
                         sid = tds[0].get_text(strip=True)
                         if sensor_ids and sid not in sensor_ids:
                             continue
-                        try:
-                            temperature = float(tds[4].get_text(strip=True))
-                        except ValueError:
-                            temperature = None
 
                         desc = tds[1].get_text(strip=True)
                         if desc == "~click to edit~":
@@ -342,14 +399,14 @@ class Omnisense:
 
                         all_sensors[sid] = {
                             "description": desc,
-                            "last_activity": tds[2].get_text(strip=True),
+                            "last_activity": _parse_timestamp(tds[2].get_text(strip=True)),
                             "status": tds[3].get_text(strip=True),
-                            "temperature": temperature,
-                            "relative_humidity": tds[5].get_text(strip=True),
-                            "absolute_humidity": tds[6].get_text(strip=True),
-                            "dew_point": tds[7].get_text(strip=True),
-                            "wood_pct": tds[8].get_text(strip=True),
-                            "battery_voltage": tds[9].get_text(strip=True),
+                            "temperature": _parse_float(tds[4].get_text(strip=True)),
+                            "relative_humidity": _parse_float(tds[5].get_text(strip=True)),
+                            "absolute_humidity": _parse_float(tds[6].get_text(strip=True)),
+                            "dew_point": _parse_float(tds[7].get_text(strip=True)),
+                            "wood_pct": _parse_float(tds[8].get_text(strip=True)),
+                            "battery_voltage": _parse_float(tds[9].get_text(strip=True)),
                             "sensor_type": sensor_type,
                             "sensor_id": sid,
                             "site_name": site_name,

--- a/tests/live_test.py
+++ b/tests/live_test.py
@@ -9,6 +9,7 @@ collaborator with valid Omnisense credentials can run this test against
 """
 
 import os
+from datetime import datetime
 
 import pytest
 from dotenv import load_dotenv
@@ -31,6 +32,15 @@ EXPECTED_SENSOR_KEYS = {
     "sensor_type",
     "sensor_id",
     "site_name",
+}
+
+NUMERIC_KEYS = {
+    "temperature",
+    "relative_humidity",
+    "absolute_humidity",
+    "dew_point",
+    "wood_pct",
+    "battery_voltage",
 }
 
 
@@ -61,3 +71,20 @@ async def test_live_login_and_fetch_data():
                 f"sensor {sensor_id} has unexpected key set: "
                 f"{set(reading.keys()) ^ EXPECTED_SENSOR_KEYS}"
             )
+
+            for key in NUMERIC_KEYS:
+                value = reading[key]
+                assert value is None or isinstance(value, float), (
+                    f"sensor {sensor_id} field {key!r} should be Optional[float], "
+                    f"got {type(value).__name__}: {value!r}"
+                )
+
+            last_activity = reading["last_activity"]
+            assert last_activity is None or isinstance(last_activity, datetime), (
+                f"sensor {sensor_id} last_activity should be Optional[datetime], "
+                f"got {type(last_activity).__name__}: {last_activity!r}"
+            )
+            if last_activity is not None:
+                assert last_activity.tzinfo is not None, (
+                    f"sensor {sensor_id} last_activity must be tz-aware"
+                )

--- a/tests/sensor_data_test.py
+++ b/tests/sensor_data_test.py
@@ -6,26 +6,34 @@ Each test sets up the *minimum* extra mocks it needs on top of the
 expected projection of ``ALL_SENSORS``.
 """
 
+from datetime import datetime, timezone
+
 import pytest
 
 from pyomnisense.omnisense import SITE_LIST_URL
+
+
+def _ts(s: str) -> datetime:
+    """Helper: parse an ``YY-MM-DD HH:MM:SS`` string as the same UTC
+    timestamp ``Omnisense.get_sensor_data`` will produce."""
+    return datetime.strptime(s, "%y-%m-%d %H:%M:%S").replace(tzinfo=timezone.utc)
 
 
 # Canonical "everything" result, computed by parsing the two sample
 # sensor_*.html files. Individual tests slice this dict to express the
 # expected result of filtering by site or sensor.
 ALL_SENSORS = {
-    "2A000001": {"description": "Dining Room",         "last_activity": "24-12-30 10:57:44", "status": "A", "temperature": 25.1, "relative_humidity": "39.0", "absolute_humidity": "7.7", "dew_point": "10.2", "wood_pct": "7.2",  "battery_voltage": "3.4", "sensor_type": "S-11",  "sensor_id": "2A000001", "site_name": "MySite"},
-    "2A000002": {"description": "Basement",            "last_activity": "24-12-30 10:59:04", "status": "A", "temperature": 29.2, "relative_humidity": "30.4", "absolute_humidity": "7.7", "dew_point": "10.1", "wood_pct": "6.9",  "battery_voltage": "3.4", "sensor_type": "S-11",  "sensor_id": "2A000002", "site_name": "MySite"},
-    "2A000003": {"description": "Gateway",             "last_activity": "24-12-22 10:55:33", "status": "A", "temperature": 11.8, "relative_humidity": "78.4", "absolute_humidity": "6.8", "dew_point": "8.3",  "wood_pct": "13.0", "battery_voltage": "3.1", "sensor_type": "S-11",  "sensor_id": "2A000003", "site_name": "MySite"},
-    "2A000004": {"description": "Kitchen",             "last_activity": "24-12-30 10:59:40", "status": "A", "temperature": 24.7, "relative_humidity": "42.1", "absolute_humidity": "8.2", "dew_point": "11.0", "wood_pct": "7.8",  "battery_voltage": "3.4", "sensor_type": "S-11",  "sensor_id": "2A000004", "site_name": "MySite"},
-    "2A000005": {"description": "Laundry Room",        "last_activity": "24-12-22 10:51:17", "status": "A", "temperature": 14.4, "relative_humidity": "63.6", "absolute_humidity": "6.5", "dew_point": "7.6",  "wood_pct": "13.2", "battery_voltage": "3.2", "sensor_type": "S-11",  "sensor_id": "2A000005", "site_name": "MySite"},
-    "6BC00000": {"description": "<description not set>", "last_activity": "24-12-30 10:59:28", "status": "A", "temperature": 0.0,  "relative_humidity": "26",   "absolute_humidity": "0",   "dew_point": "60",   "wood_pct": "11",   "battery_voltage": "0.0", "sensor_type": "S-100", "sensor_id": "6BC00000", "site_name": "MySite"},
-    "2A001001": {"description": "Dining Room",         "last_activity": "24-12-30 10:57:44", "status": "A", "temperature": 25.1, "relative_humidity": "39.0", "absolute_humidity": "7.7", "dew_point": "10.2", "wood_pct": "7.2",  "battery_voltage": "3.4", "sensor_type": "S-11",  "sensor_id": "2A001001", "site_name": "FirstSite"},
-    "2A001002": {"description": "Basement",            "last_activity": "24-12-30 10:59:04", "status": "A", "temperature": 29.2, "relative_humidity": "30.4", "absolute_humidity": "7.7", "dew_point": "10.1", "wood_pct": "6.9",  "battery_voltage": "3.4", "sensor_type": "S-11",  "sensor_id": "2A001002", "site_name": "FirstSite"},
-    "2A001003": {"description": "Gateway",             "last_activity": "24-12-22 10:55:33", "status": "A", "temperature": 11.8, "relative_humidity": "78.4", "absolute_humidity": "6.8", "dew_point": "8.3",  "wood_pct": "13.0", "battery_voltage": "3.1", "sensor_type": "S-11",  "sensor_id": "2A001003", "site_name": "FirstSite"},
-    "2A001004": {"description": "Kitchen",             "last_activity": "24-12-30 10:59:40", "status": "A", "temperature": 24.7, "relative_humidity": "42.1", "absolute_humidity": "8.2", "dew_point": "11.0", "wood_pct": "7.8",  "battery_voltage": "3.4", "sensor_type": "S-11",  "sensor_id": "2A001004", "site_name": "FirstSite"},
-    "2A001005": {"description": "Laundry Room",        "last_activity": "24-12-22 10:51:17", "status": "A", "temperature": 14.4, "relative_humidity": "63.6", "absolute_humidity": "6.5", "dew_point": "7.6",  "wood_pct": "13.2", "battery_voltage": "3.2", "sensor_type": "S-11",  "sensor_id": "2A001005", "site_name": "FirstSite"},
+    "2A000001": {"description": "Dining Room",         "last_activity": _ts("24-12-30 10:57:44"), "status": "A", "temperature": 25.1, "relative_humidity": 39.0, "absolute_humidity": 7.7, "dew_point": 10.2, "wood_pct": 7.2,  "battery_voltage": 3.4, "sensor_type": "S-11",  "sensor_id": "2A000001", "site_name": "MySite"},
+    "2A000002": {"description": "Basement",            "last_activity": _ts("24-12-30 10:59:04"), "status": "A", "temperature": 29.2, "relative_humidity": 30.4, "absolute_humidity": 7.7, "dew_point": 10.1, "wood_pct": 6.9,  "battery_voltage": 3.4, "sensor_type": "S-11",  "sensor_id": "2A000002", "site_name": "MySite"},
+    "2A000003": {"description": "Gateway",             "last_activity": _ts("24-12-22 10:55:33"), "status": "A", "temperature": 11.8, "relative_humidity": 78.4, "absolute_humidity": 6.8, "dew_point": 8.3,  "wood_pct": 13.0, "battery_voltage": 3.1, "sensor_type": "S-11",  "sensor_id": "2A000003", "site_name": "MySite"},
+    "2A000004": {"description": "Kitchen",             "last_activity": _ts("24-12-30 10:59:40"), "status": "A", "temperature": 24.7, "relative_humidity": 42.1, "absolute_humidity": 8.2, "dew_point": 11.0, "wood_pct": 7.8,  "battery_voltage": 3.4, "sensor_type": "S-11",  "sensor_id": "2A000004", "site_name": "MySite"},
+    "2A000005": {"description": "Laundry Room",        "last_activity": _ts("24-12-22 10:51:17"), "status": "A", "temperature": 14.4, "relative_humidity": 63.6, "absolute_humidity": 6.5, "dew_point": 7.6,  "wood_pct": 13.2, "battery_voltage": 3.2, "sensor_type": "S-11",  "sensor_id": "2A000005", "site_name": "MySite"},
+    "6BC00000": {"description": "<description not set>", "last_activity": _ts("24-12-30 10:59:28"), "status": "A", "temperature": 0.0,  "relative_humidity": 26.0, "absolute_humidity": 0.0, "dew_point": 60.0, "wood_pct": 11.0, "battery_voltage": 0.0, "sensor_type": "S-100", "sensor_id": "6BC00000", "site_name": "MySite"},
+    "2A001001": {"description": "Dining Room",         "last_activity": _ts("24-12-30 10:57:44"), "status": "A", "temperature": 25.1, "relative_humidity": 39.0, "absolute_humidity": 7.7, "dew_point": 10.2, "wood_pct": 7.2,  "battery_voltage": 3.4, "sensor_type": "S-11",  "sensor_id": "2A001001", "site_name": "FirstSite"},
+    "2A001002": {"description": "Basement",            "last_activity": _ts("24-12-30 10:59:04"), "status": "A", "temperature": 29.2, "relative_humidity": 30.4, "absolute_humidity": 7.7, "dew_point": 10.1, "wood_pct": 6.9,  "battery_voltage": 3.4, "sensor_type": "S-11",  "sensor_id": "2A001002", "site_name": "FirstSite"},
+    "2A001003": {"description": "Gateway",             "last_activity": _ts("24-12-22 10:55:33"), "status": "A", "temperature": 11.8, "relative_humidity": 78.4, "absolute_humidity": 6.8, "dew_point": 8.3,  "wood_pct": 13.0, "battery_voltage": 3.1, "sensor_type": "S-11",  "sensor_id": "2A001003", "site_name": "FirstSite"},
+    "2A001004": {"description": "Kitchen",             "last_activity": _ts("24-12-30 10:59:40"), "status": "A", "temperature": 24.7, "relative_humidity": 42.1, "absolute_humidity": 8.2, "dew_point": 11.0, "wood_pct": 7.8,  "battery_voltage": 3.4, "sensor_type": "S-11",  "sensor_id": "2A001004", "site_name": "FirstSite"},
+    "2A001005": {"description": "Laundry Room",        "last_activity": _ts("24-12-22 10:51:17"), "status": "A", "temperature": 14.4, "relative_humidity": 63.6, "absolute_humidity": 6.5, "dew_point": 7.6,  "wood_pct": 13.2, "battery_voltage": 3.2, "sensor_type": "S-11",  "sensor_id": "2A001005", "site_name": "FirstSite"},
 }
 
 SITE_123456_IDS = {sid for sid, info in ALL_SENSORS.items() if info["site_name"] == "MySite"}

--- a/tests/session_reuse_test.py
+++ b/tests/session_reuse_test.py
@@ -8,10 +8,20 @@ configured with ``quote_cookie=False``:
 * If the server bounces a data request back to the login page (because
   the cached session expired), the client should transparently re-login
   once and retry without the caller having to know.
+* If the *retry* also lands on the login page, the failure must
+  propagate as ``OmnisenseAuthError`` instead of silently returning
+  empty data.
+* Cookie values with ``=`` / ``+`` characters (omnisense.com is a
+  Classic ASP site that emits them) must round-trip verbatim on the
+  next request - aiohttp's default cookie jar percent-encodes them and
+  breaks the session.
 """
 
 import pytest
 from aioresponses import aioresponses
+from yarl import URL
+
+import aiohttp
 
 from pyomnisense.omnisense import (
     HOST_URL,
@@ -124,3 +134,127 @@ async def test_context_manager_closes_session(register_login):
 
         assert omnisense._session is None
         assert session.closed
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_get_sensor_data_propagates_auth_error_on_unrecoverable_expiry(
+    logged_in, register_login
+):
+    """If a sensor-data fetch lands on the login page AND the transparent
+    re-login also lands on the login page, ``get_sensor_data`` must raise
+    ``OmnisenseAuthError`` instead of silently returning ``{}`` -- callers
+    have to be able to tell "session is dead" apart from "transient site
+    scrape failure"."""
+    omnisense, m = logged_in
+
+    sensor_url = f"{SENSOR_LIST_URL}?siteNbr=123456"
+
+    # First GET: server 302s to the login page (session expired).
+    m.get(sensor_url, status=302, headers={"Location": "/user_login.asp"})
+    m.get(
+        f"{HOST_URL}/user_login.asp",
+        status=200,
+        body="<html><form>login form</form></html>",
+    )
+
+    # Transparent re-login happens.
+    register_login(m, set_cookie="ASP.NET_SessionId=def456; Path=/; HttpOnly")
+
+    # Retry of the original GET: server STILL 302s to login (creds are
+    # bad or the server's session table is broken).
+    m.get(sensor_url, status=302, headers={"Location": "/user_login.asp"})
+    m.get(
+        f"{HOST_URL}/user_login.asp",
+        status=200,
+        body="<html><form>login form</form></html>",
+    )
+
+    with pytest.raises(OmnisenseAuthError):
+        await omnisense.get_sensor_data("123456")
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_get_site_list_propagates_auth_error_on_unrecoverable_expiry(
+    logged_in, register_login
+):
+    """Same contract as ``get_sensor_data``: an unrecoverable auth failure
+    must surface as ``OmnisenseAuthError``, not a silent empty result."""
+    omnisense, m = logged_in
+
+    m.get(SITE_LIST_URL, status=302, headers={"Location": "/user_login.asp"})
+    m.get(
+        f"{HOST_URL}/user_login.asp",
+        status=200,
+        body="<html><form>login form</form></html>",
+    )
+    register_login(m, set_cookie="ASP.NET_SessionId=def456; Path=/; HttpOnly")
+    m.get(SITE_LIST_URL, status=302, headers={"Location": "/user_login.asp"})
+    m.get(
+        f"{HOST_URL}/user_login.asp",
+        status=200,
+        body="<html><form>login form</form></html>",
+    )
+
+    with pytest.raises(OmnisenseAuthError):
+        await omnisense.get_site_list()
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_cookies_preserved_verbatim_for_classic_asp():
+    """Regression guard for #22: omnisense.com (Classic ASP) emits
+    ``Set-Cookie`` values containing characters such as ``=`` and ``+``
+    (e.g. ``userPNSToken=login+failed``). aiohttp's *default*
+    ``CookieJar`` wraps such values in double quotes when serializing them
+    onto the next request's ``Cookie`` header (you can see this by
+    comparing ``Morsel.coded_value`` between the default jar and one
+    constructed with ``quote_cookie=False``). The ASP server treats the
+    quoted form as a different value and rejects our session.
+
+    To guard against this we (a) check the configuration directly and
+    (b) feed a cookie with a ``+`` through the configured jar and assert
+    that ``coded_value`` - the form aiohttp writes to the wire - matches
+    the raw server value byte-for-byte.
+
+    (We can't use aioresponses to test the *full* round-trip because
+    aioresponses doesn't push ``Set-Cookie`` headers from mocked
+    responses through aiohttp's cookie-jar pipeline.)
+    """
+    omnisense = Omnisense()
+    omnisense._open_session()
+    try:
+        jar = omnisense._session.cookie_jar
+
+        # (a) Configuration check: jar is aiohttp.CookieJar with
+        # quote_cookie disabled.
+        assert isinstance(jar, aiohttp.CookieJar)
+        assert jar.quote_cookie is False, (
+            "Omnisense._session.cookie_jar was constructed with cookie "
+            "quoting enabled. classic-ASP cookies from omnisense.com "
+            "contain '=' / '+' characters that get wrapped in double "
+            "quotes (or percent-encoded) on the next outgoing request, "
+            "which breaks server-side auth. Use "
+            "aiohttp.CookieJar(quote_cookie=False) in _open_session."
+        )
+
+        # (b) Behavioural check: feed a server-set cookie with a '+' and
+        # confirm the coded_value (what aiohttp will write to the wire)
+        # equals the raw value rather than being wrapped in double quotes.
+        jar.update_cookies(
+            {"userPNSToken": "login+failed"}, URL(HOST_URL)
+        )
+        sent = jar.filter_cookies(URL(HOST_URL))
+        morsel = sent["userPNSToken"]
+        assert morsel.value == "login+failed"
+        assert morsel.coded_value == "login+failed", (
+            "Cookie containing '+' was re-quoted by the jar: "
+            f"coded_value={morsel.coded_value!r}. This is what aiohttp "
+            "writes to the outgoing Cookie header, so omnisense.com will "
+            "see e.g. 'userPNSToken=\"login+failed\"' and reject the "
+            "session. The fix is aiohttp.CookieJar(quote_cookie=False) "
+            "in Omnisense._open_session."
+        )
+    finally:
+        await omnisense.close()


### PR DESCRIPTION
**Closes parts of #4.** Continuation of the cleanup work from #6/#7/#8.

## :warning: Breaking change to `SensorReading`

Numeric columns and `last_activity` are now parsed once inside the library:

| field | before | after |
| --- | --- | --- |
| `temperature` / `relative_humidity` / `dew_point` / `wood_pct` / `battery_voltage` / `rssi` | mostly `str` (only `temperature` was coerced to `float`) | `Optional[float]` |
| `last_activity` | `str` | `Optional[datetime]` (tz-aware UTC) |

Values that can't be parsed become `None` rather than torpedoing the whole scrape. `omnisense.com` emits timestamps in UTC, which is what the parsed datetimes carry.

Downstream consumers (`hass_omnisense`) will need a matching version bump; PR for that to follow.

## Issue #4 items in this PR

- **#8** `get_sensor_data` and `get_site_list` no longer silently swallow `OmnisenseAuthError` via their catch-all `except Exception` block. Auth failures now propagate to the caller instead of returning an empty `{}`.
- **#9** All six numeric columns + `last_activity` are parsed once in the library, via new module-level `_parse_float` / `_parse_timestamp` helpers, instead of leaving each caller to coerce strings.
- **#11** `get_site_sensor_list` simplified to a pure dict-comprehension over `get_sensor_data`; the redundant `try/except` wrapper that hid auth errors is gone.
- **#22** Added `test_cookies_preserved_verbatim_for_classic_asp` regression guard for the `aiohttp.CookieJar(quote_cookie=False)` behaviour the classic-ASP omnisense.com server depends on. Also added two new regression tests covering the **#8** fix.
- **nits** Expanded docstrings on `get_site_list` and `get_sensor_data` to document implicit auto-login behaviour and the new return types.

## Tests

`pytest -m offline -p no:timeout -q` -> **28 passed, 1 deselected** (was 25 passed before this PR). Live test (`tests/live_test.py`) updated to assert the new types when run against the real site.