### PR TITLE
pyomnisense 0.3.1: drop the proxy_url debugging attribute

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyomnisense"          
-version = "0.3.0"             
+version = "0.3.1"             
 description = "Python library for accessing Omnisense sensor data from omnisense.com"
 readme = "README.md"          
 license = { text = "MIT" }    

--- a/src/pyomnisense/__init__.py
+++ b/src/pyomnisense/__init__.py
@@ -11,4 +11,4 @@ __all__ = [
     "OmnisenseError",
     "SensorReading",
 ]
-__version__ = "0.3.0"
+__version__ = "0.3.1"

--- a/src/pyomnisense/omnisense.py
+++ b/src/pyomnisense/omnisense.py
@@ -99,10 +99,6 @@ class Omnisense:
             ),
         }
 
-        # Set to a URL (e.g. "http://127.0.0.1:8888") to route traffic through
-        # a debugging proxy; leave as None for normal operation.
-        self.proxy_url: Optional[str] = None
-
     def _open_session(self) -> None:
         # quote_cookie=False is load-bearing: omnisense.com is a classic ASP
         # site whose Set-Cookie values contain characters ('=', '+') that
@@ -170,7 +166,6 @@ class Omnisense:
         async with self._session.post(
             LOGIN_URL,
             data=payload,
-            proxy=self.proxy_url,
             allow_redirects=False,
         ) as resp:
             _LOGGER.debug("Login POST status: %s", resp.status)
@@ -194,7 +189,7 @@ class Omnisense:
 
         # Follow the redirect. Cookies set on the POST response are now in
         # the jar and will be attached automatically.
-        async with self._session.get(location, proxy=self.proxy_url) as resp:
+        async with self._session.get(location) as resp:
             if resp.status != 200:
                 _LOGGER.error(
                     "Post-login GET %s returned status %s", location, resp.status
@@ -222,7 +217,7 @@ class Omnisense:
         await self._ensure_session()
 
         for attempt in (0, 1):
-            async with self._session.get(url, proxy=self.proxy_url) as resp:
+            async with self._session.get(url) as resp:
                 if resp.status != 200:
                     raise OmnisenseError(
                         f"GET {url} returned status {resp.status}"


### PR DESCRIPTION
Final cleanup item from the 28-item code review (issue #4).

The `proxy_url` field had been promoted from a commented-out mitmproxy line into an `Optional[str]` attribute that was passed as `proxy=` to every outgoing request. In practice it's never used and adds noise to every call site; if you need to route through a debugging proxy, set `HTTPS_PROXY` in the environment or construct your own aiohttp session.

Removes:

- `self.proxy_url` attribute and its initialiser comment
- `proxy=self.proxy_url` kwargs from the login POST, the post-login GET, and `_fetch_html`'s GET

No behavioural change for any caller that wasn't poking `proxy_url` directly. All 28 offline tests still pass.

With this in, every actionable item in #4 is closed; intent is to close that issue after this lands.